### PR TITLE
Add design system example app with TrackingObserver and schema-driven Adobe SDK blocking

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,29 +1,22 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# Deploy the yourbank-design example app to GitHub Pages
+name: Deploy Example App to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
+  build-and-deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -31,13 +24,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build design system library
+        run: yarn workspace yourbank-design build
+
+      - name: Build example app
+        run: yarn workspace yourbank-design-example build
+        env:
+          # Required for CRA to produce correct relative asset paths on GitHub Pages
+          PUBLIC_URL: /YourBank
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: "./apps/yourbank-ui/build"
+          path: "./libs/yourbank-design/example/build"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,807 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>YourBank — Design System Example</title>
+  <style>
+    /* ── Reset & base ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      color: #333;
+      background: #f0f0f0;
+      min-height: 100vh;
+    }
+
+    /* ── Header ── */
+    .yb-header {
+      background: #c0392b;
+      color: #fff;
+      padding: 14px 40px;
+      box-shadow: 0 2px 4px rgba(0,0,0,.15);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    .yb-logo { font-size: 22px; font-weight: 700; letter-spacing: 1px; }
+    .yb-nav { display: flex; gap: 8px; }
+    .yb-nav button {
+      background: transparent;
+      border: 2px solid rgba(255,255,255,.5);
+      color: #fff;
+      padding: 6px 16px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      transition: background .2s, border-color .2s;
+    }
+    .yb-nav button:hover { background: rgba(255,255,255,.15); border-color: #fff; }
+    .yb-nav button.active { background: rgba(255,255,255,.25); border-color: #fff; }
+
+    /* ── Container / layout ── */
+    .yb-container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 28px 24px;
+    }
+    .yb-card-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      justify-content: center;
+      padding: 8px 0;
+    }
+
+    /* ── Card ── */
+    .yb-card {
+      background: #f7f7f7;
+      border-radius: 8px;
+      box-shadow: 0 2px 5px rgba(0,0,0,.1);
+      flex: 1 1 calc(25% - 16px);
+      min-width: 200px;
+      max-width: 260px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .yb-card--wide { flex: 1 1 calc(50% - 16px); max-width: 500px; }
+    .yb-card--full { flex: 1 1 100%; max-width: 760px; margin: 0 auto; }
+    .yb-card__header {
+      padding: 20px 16px 12px;
+      border-bottom: 1px solid #e0e0e0;
+      text-align: center;
+    }
+    .yb-card__icon { width: 64px; height: 64px; margin: 0 auto 10px; }
+    .yb-card__icon svg { width: 100%; height: 100%; fill: #c0392b; }
+    .yb-card__title { font-size: 16px; font-weight: 700; color: #222; }
+    .yb-card__body { padding: 16px; flex: 1; color: #666; font-size: 14px; text-align: center; }
+    .yb-card__footer {
+      padding: 14px 16px;
+      border-top: 1px solid #e0e0e0;
+      display: flex;
+      justify-content: center;
+    }
+
+    /* ── Buttons ── */
+    .yb-btn {
+      padding: 10px 22px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      transition: background .2s;
+    }
+    .yb-btn--primary { background: #c0392b; color: #fff; }
+    .yb-btn--primary:hover { background: #e74c3c; }
+    .yb-btn--secondary {
+      background: transparent;
+      color: #c0392b;
+      border: 2px solid #c0392b;
+    }
+    .yb-btn--secondary:hover { background: #fdf0ef; }
+
+    /* ── Form ── */
+    .yb-form-section-title {
+      font-size: 12px;
+      font-weight: 700;
+      color: #c0392b;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #e8e8e8;
+      margin-bottom: 20px;
+      margin-top: 28px;
+    }
+    .yb-form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0 24px;
+    }
+    @media (max-width: 580px) { .yb-form-grid { grid-template-columns: 1fr; } }
+    .yb-form-group { display: flex; flex-direction: column; gap: 5px; margin-bottom: 18px; }
+    .yb-label { font-size: 13px; font-weight: 600; color: #444; }
+    .yb-required { color: #c0392b; }
+    .yb-input {
+      width: 100%;
+      padding: 9px 12px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 15px;
+      color: #333;
+      background: #fff;
+      transition: border-color .2s, box-shadow .2s;
+      appearance: none;
+    }
+    .yb-input:focus {
+      outline: none;
+      border-color: #c0392b;
+      box-shadow: 0 0 0 3px rgba(192,57,43,.12);
+    }
+
+    /* Blocked fields are stamped by the TrackingObserver — no component code needed */
+    .yb-input[data-tracking-blocked="true"] {
+      border-color: #bbb;
+      border-style: dashed;
+      background: #fafafa;
+    }
+
+    .yb-form-intro {
+      background: #fff8f7;
+      border: 1px solid #f5c6c1;
+      border-radius: 6px;
+      padding: 14px 18px;
+      font-size: 13px;
+      color: #555;
+      margin-bottom: 8px;
+      line-height: 1.7;
+    }
+    .yb-form-intro code {
+      background: #f0f0f0;
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+    .yb-form-actions {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 28px;
+      gap: 12px;
+    }
+
+    /* ── Confirmation ── */
+    .yb-confirm-icon {
+      width: 72px; height: 72px;
+      border-radius: 50%;
+      background: #e8f5e9;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 20px;
+      font-size: 36px;
+      color: #2e7d32;
+    }
+    .yb-confirm-ref {
+      background: #f7f7f7;
+      border: 1px solid #e0e0e0;
+      border-radius: 6px;
+      padding: 14px 28px;
+      display: inline-block;
+      margin-bottom: 28px;
+      text-align: center;
+    }
+    .yb-confirm-ref__label { font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: .5px; }
+    .yb-confirm-ref__value { font-size: 20px; font-weight: 700; letter-spacing: 2px; margin-top: 4px; }
+    .yb-summary-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    .yb-summary-table td { padding: 7px 0; border-bottom: 1px solid #f0f0f0; vertical-align: top; }
+    .yb-summary-table td:first-child { color: #888; width: 45%; }
+    .yb-summary-table td:last-child { font-weight: 500; }
+    .yb-summary-box {
+      background: #fafafa;
+      border: 1px solid #e8e8e8;
+      border-radius: 6px;
+      padding: 18px 22px;
+      margin-bottom: 24px;
+      text-align: left;
+    }
+
+    /* ── Adobe SDK Event Console ── */
+    #sdk-console {
+      position: fixed;
+      bottom: 0; left: 0; right: 0;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      font-family: 'Menlo', 'Consolas', monospace;
+      font-size: 12px;
+      z-index: 9999;
+      border-top: 3px solid #c0392b;
+      display: flex;
+      flex-direction: column;
+      max-height: 260px;
+      transition: max-height .25s ease;
+    }
+    #sdk-console.collapsed { max-height: 36px; overflow: hidden; }
+    #sdk-console-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 14px;
+      background: #2d2d2d;
+      cursor: pointer;
+      flex-shrink: 0;
+      user-select: none;
+    }
+    .sdk-dot { color: #c0392b; font-weight: 700; margin-right: 6px; }
+    .sdk-hint { color: #555; font-size: 11px; margin-left: 8px; }
+    #sdk-count { color: #888; }
+    #sdk-log { overflow-y: auto; flex: 1; }
+    .sdk-entry {
+      padding: 3px 16px;
+      border-bottom: 1px solid #2a2a2a;
+      cursor: pointer;
+      line-height: 1.7;
+    }
+    .sdk-entry:hover { background: #252526; }
+    .sdk-time { color: #555; margin-right: 8px; }
+    .sdk-name { font-weight: 600; }
+    .sdk-meta { color: #aaa; margin-left: 10px; font-size: 11px; }
+    .sdk-detail {
+      margin: 4px 0 4px 24px;
+      background: #252526;
+      color: #9cdcfe;
+      padding: 8px 12px;
+      border-radius: 4px;
+      white-space: pre;
+      font-size: 11px;
+      overflow-x: auto;
+    }
+    .sdk-empty { padding: 12px 16px; color: #555; font-style: italic; }
+
+    /* ── Pages ── */
+    .page { display: none; }
+    .page.active { display: block; }
+  </style>
+</head>
+<body>
+
+<!-- Header -->
+<header class="yb-header">
+  <div class="yb-logo">YourBank</div>
+  <nav class="yb-nav">
+    <button id="nav-home" class="active" onclick="navigate('landing')">Home</button>
+    <button id="nav-apply" onclick="navigate('application')">Apply Now</button>
+    <button id="nav-confirm" style="display:none" onclick="navigate('confirmation')">Confirmation</button>
+  </nav>
+</header>
+
+<!-- ══════════════════════════════════════════════════════════
+     PAGE: LANDING
+════════════════════════════════════════════════════════════ -->
+<div id="page-landing" class="page active">
+  <div class="yb-container">
+    <div class="yb-card-grid">
+
+      <div class="yb-card">
+        <div class="yb-card__header">
+          <div class="yb-card__icon">
+            <svg viewBox="0 0 20 17" xmlns="http://www.w3.org/2000/svg">
+              <path d="M15.274,6.505H1.252c-0.484,0-0.876,0.392-0.876,0.876v7.887c0,0.484,0.392,0.876,0.876,0.876h14.022c0.483,0,0.876-0.392,0.876-0.876V7.381C16.15,6.897,15.758,6.505,15.274,6.505M8.263,8.257c-1.694,0-3.067,1.374-3.067,3.067c0,1.695,1.373,3.068,3.067,3.068c1.695,0,3.067-1.373,3.067-3.068C11.33,9.631,9.958,8.257,8.263,8.257M18.78,3.875H4.757c-0.484,0-0.876,0.392-0.876,0.876V5.19c0,0.242,0.196,0.438,0.438,0.438c0.242,0,0.438-0.196,0.438-0.438V4.752H18.78v7.888h-1.315c-0.242,0-0.438,0.196-0.438,0.438c0,0.243,0.195,0.438,0.438,0.438h1.315c0.483,0,0.876-0.393,0.876-0.876V4.752C19.656,4.268,19.264,3.875,18.78,3.875"/>
+            </svg>
+          </div>
+          <div class="yb-card__title">YourMoney</div>
+        </div>
+        <div class="yb-card__body">We can help you move money. Anywhere, Anytime.</div>
+        <div class="yb-card__footer">
+          <button class="yb-btn yb-btn--primary" data-track-click onclick="navigate('application')">Get Started</button>
+        </div>
+      </div>
+
+      <div class="yb-card">
+        <div class="yb-card__header">
+          <div class="yb-card__icon">
+            <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+              <path d="M18.121,9.88l-7.832-7.836c-0.155-0.158-0.428-0.155-0.584,0L1.842,9.913c-0.262,0.263-0.073,0.705,0.292,0.705h2.069v7.042c0,0.227,0.187,0.414,0.414,0.414h3.725c0.228,0,0.414-0.188,0.414-0.414v-3.313h2.483v3.313c0,0.227,0.187,0.414,0.413,0.414h3.726c0.229,0,0.414-0.188,0.414-0.414v-7.042h2.068h0.004C18.331,10.617,18.389,10.146,18.121,9.88z"/>
+            </svg>
+          </div>
+          <div class="yb-card__title">YourLoans</div>
+        </div>
+        <div class="yb-card__body">We can help you get and manage credit.</div>
+        <div class="yb-card__footer">
+          <button class="yb-btn yb-btn--primary" data-track-click onclick="navigate('application')">Apply Now</button>
+        </div>
+      </div>
+
+      <div class="yb-card">
+        <div class="yb-card__header">
+          <div class="yb-card__icon">
+            <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+              <path d="M10.281,1.781C5.75,1.781,2.062,5.469,2.062,10s3.688,8.219,8.219,8.219S18.5,14.531,18.5,10S14.812,1.781,10.281,1.781M10.714,2.659c3.712,0.216,6.691,3.197,6.907,6.908h-6.907V2.659z M10.281,17.354c-4.055,0-7.354-3.298-7.354-7.354c0-3.911,3.067-7.116,6.921-7.341V10c0,0.115,0.045,0.225,0.127,0.305l5.186,5.189C13.863,16.648,12.154,17.354,10.281,17.354M15.775,14.882l-4.449-4.449h6.295C17.522,12.135,16.842,13.684,15.775,14.882"/>
+            </svg>
+          </div>
+          <div class="yb-card__title">YourInsights</div>
+        </div>
+        <div class="yb-card__body">We can help you find your next big thing.</div>
+        <div class="yb-card__footer">
+          <button class="yb-btn yb-btn--primary" data-track-click onclick="navigate('application')">Get Started</button>
+        </div>
+      </div>
+
+      <div class="yb-card">
+        <div class="yb-card__header">
+          <div class="yb-card__icon">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12,2L15,8L21,9L16,13L17,19L12,16L7,19L8,13L3,9L9,8L12,2Z"/>
+            </svg>
+          </div>
+          <div class="yb-card__title">YourRelationship</div>
+        </div>
+        <div class="yb-card__body">We're in this together.</div>
+        <div class="yb-card__footer">
+          <button class="yb-btn yb-btn--primary" data-track-click onclick="navigate('application')">Get Started</button>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="yb-card-grid" style="margin-top:16px">
+      <div class="yb-card yb-card--wide">
+        <div class="yb-card__header"><div class="yb-card__title">About Us</div></div>
+        <div class="yb-card__body">Learn who we are, and why we care so much about you.</div>
+        <div class="yb-card__footer"><button class="yb-btn yb-btn--secondary" data-track-click>Learn More</button></div>
+      </div>
+      <div class="yb-card yb-card--wide">
+        <div class="yb-card__header"><div class="yb-card__title">Invest</div></div>
+        <div class="yb-card__body">YourBank — it's not just how we operate, it's how we're owned.</div>
+        <div class="yb-card__footer"><button class="yb-btn yb-btn--secondary" data-track-click>Learn More</button></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════
+     PAGE: APPLICATION FORM
+════════════════════════════════════════════════════════════ -->
+<div id="page-application" class="page">
+  <div class="yb-container">
+    <div class="yb-card-grid">
+      <div class="yb-card yb-card--full">
+        <div class="yb-card__header"><div class="yb-card__title">Loan Application</div></div>
+        <div class="yb-card__body" style="text-align:left; padding:24px 28px;">
+
+          <div class="yb-form-intro">
+            Fields marked with 🔒 are <strong>protected</strong>: the
+            <code>TrackingObserver</code> reads the schema and suppresses all Adobe SDK
+            events on those inputs automatically — no changes to this form were required.
+            The only coupling is the <code>data-field-id</code> attribute used as a CSS
+            selector in <code>tracking-schema.ts</code>.
+          </div>
+
+          <form id="loan-form" data-form-id="loan-application" novalidate>
+
+            <div class="yb-form-section-title">Personal Information</div>
+            <div class="yb-form-grid">
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="first-name">
+                  First Name <span class="yb-required">*</span>
+                </label>
+                <!-- data-field-id="first-name" → TRACKED -->
+                <input class="yb-input" id="first-name" data-field-id="first-name"
+                  type="text" autocomplete="given-name" placeholder="Jane" required />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="last-name">
+                  Last Name <span class="yb-required">*</span>
+                </label>
+                <!-- data-field-id="last-name" → TRACKED -->
+                <input class="yb-input" id="last-name" data-field-id="last-name"
+                  type="text" autocomplete="family-name" placeholder="Smith" required />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="email">
+                  Email <span class="yb-required">*</span>
+                </label>
+                <!-- data-field-id="email" → TRACKED -->
+                <input class="yb-input" id="email" data-field-id="email"
+                  type="email" autocomplete="email" placeholder="jane@example.com" required />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="phone">Phone</label>
+                <!-- data-field-id="phone" → TRACKED -->
+                <input class="yb-input" id="phone" data-field-id="phone"
+                  type="tel" autocomplete="tel" placeholder="(555) 000-0000" />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="dob">
+                  Date of Birth <span class="yb-required">*</span>
+                  <span title="Protected — not tracked by Adobe SDK">🔒</span>
+                </label>
+                <!--
+                  data-field-id="dob" → BLOCKED: sensitive_pii
+                  TrackingObserver stamps this with data-tracking-blocked="true"
+                  No change to this input was required for blocking to work.
+                -->
+                <input class="yb-input" id="dob" data-field-id="dob"
+                  type="date" autocomplete="bday" required />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="ssn">
+                  Social Security Number <span class="yb-required">*</span>
+                  <span title="Protected — not tracked by Adobe SDK">🔒</span>
+                </label>
+                <!-- data-field-id="ssn" → BLOCKED: sensitive_pii -->
+                <input class="yb-input" id="ssn" data-field-id="ssn"
+                  type="password" autocomplete="off" placeholder="XXX-XX-XXXX" required />
+              </div>
+
+            </div>
+
+            <div class="yb-form-section-title">Loan Details</div>
+            <div class="yb-form-grid">
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="loan-amount">
+                  Requested Amount ($) <span class="yb-required">*</span>
+                </label>
+                <!-- data-field-id="loan-amount" → TRACKED -->
+                <input class="yb-input" id="loan-amount" data-field-id="loan-amount"
+                  type="number" min="1000" max="100000" step="500"
+                  placeholder="25000" required />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="loan-purpose">
+                  Loan Purpose <span class="yb-required">*</span>
+                </label>
+                <!-- data-field-id="loan-purpose" → TRACKED -->
+                <select class="yb-input" id="loan-purpose" data-field-id="loan-purpose" required>
+                  <option value="">Select a purpose…</option>
+                  <option value="home-improvement">Home Improvement</option>
+                  <option value="debt-consolidation">Debt Consolidation</option>
+                  <option value="auto">Auto Purchase</option>
+                  <option value="education">Education</option>
+                  <option value="business">Small Business</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="monthly-income">
+                  Monthly Gross Income ($) <span class="yb-required">*</span>
+                </label>
+                <!-- data-field-id="monthly-income" → TRACKED -->
+                <input class="yb-input" id="monthly-income" data-field-id="monthly-income"
+                  type="number" min="0" placeholder="5000" required />
+              </div>
+
+              <div class="yb-form-group">
+                <label class="yb-label" for="account-number">
+                  YourBank Account Number <span class="yb-required">*</span>
+                  <span title="Protected — not tracked by Adobe SDK">🔒</span>
+                </label>
+                <!-- data-field-id="account-number" → BLOCKED: financial -->
+                <input class="yb-input" id="account-number" data-field-id="account-number"
+                  type="password" autocomplete="off" placeholder="Account number" required />
+              </div>
+
+            </div>
+
+            <div class="yb-form-actions">
+              <button type="button" class="yb-btn yb-btn--secondary"
+                onclick="navigate('landing')">Back</button>
+              <button type="submit" class="yb-btn yb-btn--primary">Submit Application</button>
+            </div>
+
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════
+     PAGE: CONFIRMATION
+════════════════════════════════════════════════════════════ -->
+<div id="page-confirmation" class="page">
+  <div class="yb-container">
+    <div class="yb-card-grid">
+      <div class="yb-card yb-card--full">
+        <div class="yb-card__header"><div class="yb-card__title">Application Submitted</div></div>
+        <div class="yb-card__body" style="text-align:center; padding:28px;">
+          <div class="yb-confirm-icon">✓</div>
+          <h3 id="confirm-name" style="color:#2e7d32;margin-bottom:8px;font-size:20px;font-family:Georgia,serif"></h3>
+          <p style="color:#666;margin-bottom:24px">Your loan application has been received and is under review.</p>
+          <div class="yb-confirm-ref">
+            <div class="yb-confirm-ref__label">Reference Number</div>
+            <div class="yb-confirm-ref__value" id="confirm-ref"></div>
+          </div>
+          <div class="yb-summary-box">
+            <div style="font-weight:700;color:#c0392b;text-transform:uppercase;font-size:12px;letter-spacing:.5px;margin-bottom:14px">
+              Application Summary
+            </div>
+            <table class="yb-summary-table" id="confirm-summary"></table>
+            <p style="font-size:12px;color:#999;margin-top:12px">
+              🔒 Protected fields (SSN, Date of Birth, Account Number) are not displayed for security.
+            </p>
+          </div>
+          <button class="yb-btn yb-btn--primary" onclick="navigate('landing')">Back to Home</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Console spacer -->
+<div id="console-spacer" style="height:260px"></div>
+
+<!-- ══════════════════════════════════════════════════════════
+     Adobe Web SDK Event Console (simulated)
+════════════════════════════════════════════════════════════ -->
+<div id="sdk-console">
+  <div id="sdk-console-header" onclick="toggleConsole()">
+    <span>
+      <span class="sdk-dot">●</span>
+      Adobe Web SDK Event Console
+      <span class="sdk-hint">(simulated — blocked fields never appear here)</span>
+    </span>
+    <span id="sdk-count">0 events ▼</span>
+  </div>
+  <div id="sdk-log">
+    <div class="sdk-empty">Interact with the form to see tracking events…</div>
+  </div>
+</div>
+
+<script>
+// ═══════════════════════════════════════════════════════════════════════
+//  Tracking Schema
+//  Source of truth: libs/yourbank-design/example/src/tracking-schema.ts
+// ═══════════════════════════════════════════════════════════════════════
+const SCHEMA = {
+  version: '1.0.0',
+  eventPrefix: 'yourbank:',
+  blockedFields: [
+    { selector: "[data-field-id='ssn']",            reason: 'Social Security Number — sensitive PII',          category: 'sensitive_pii' },
+    { selector: "[data-field-id='dob']",            reason: 'Date of Birth — sensitive PII (CCPA/GDPR)',        category: 'sensitive_pii' },
+    { selector: "[data-field-id='account-number']", reason: 'Account number — sensitive financial data',        category: 'financial'     },
+    { selector: "[data-field-id='password']",       reason: 'Password — credential, must never be tracked',    category: 'credential'    }
+  ]
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+//  TrackingObserver
+//  Source: libs/yourbank-design/src/tracking/TrackingObserver.ts
+// ═══════════════════════════════════════════════════════════════════════
+class TrackingObserver {
+  constructor(schema) {
+    this.schema = schema;
+    this.currentPage = '';
+    this.listening = false;
+    this._handle = this._handleEvent.bind(this);
+  }
+
+  setPage(pageName) {
+    this.currentPage = pageName;
+    this._dispatch('pageView', { eventType: 'pageView', pageName, timestamp: new Date().toISOString() });
+  }
+
+  start() {
+    if (this.listening) return;
+    this.listening = true;
+    ['input','change','focus','blur','click','submit']
+      .forEach(t => document.addEventListener(t, this._handle, true));
+    this._mo = new MutationObserver(mutations =>
+      mutations.forEach(({ addedNodes }) =>
+        addedNodes.forEach(n => { if (n.nodeType === 1) this._stamp(n); })));
+    this._mo.observe(document.body, { childList: true, subtree: true });
+    this._stamp(document.body);
+  }
+
+  stop() {
+    if (!this.listening) return;
+    this.listening = false;
+    ['input','change','focus','blur','click','submit']
+      .forEach(t => document.removeEventListener(t, this._handle, true));
+    if (this._mo) this._mo.disconnect();
+  }
+
+  /** Stamp matching elements with data-tracking-blocked so Adobe SDK can filter natively */
+  _stamp(root) {
+    this.schema.blockedFields.forEach(rule => {
+      try {
+        root.querySelectorAll(rule.selector).forEach(el => {
+          el.setAttribute('data-tracking-blocked', 'true');
+          el.setAttribute('data-tracking-block-reason', rule.reason);
+          el.setAttribute('data-tracking-block-category', rule.category);
+        });
+        if (root.matches && root.matches(rule.selector)) {
+          root.setAttribute('data-tracking-blocked', 'true');
+          root.setAttribute('data-tracking-block-reason', rule.reason);
+          root.setAttribute('data-tracking-block-category', rule.category);
+        }
+      } catch(_) {}
+    });
+  }
+
+  _isBlocked(el) {
+    let node = el;
+    while (node) {
+      if (node.getAttribute && node.getAttribute('data-tracking-blocked') === 'true') return true;
+      for (const rule of this.schema.blockedFields) {
+        try { if (node.matches && node.matches(rule.selector)) return true; } catch(_) {}
+      }
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  _handleEvent(event) {
+    const t = event.target;
+    if (!t || !t.tagName) return;
+    const tag = t.tagName.toUpperCase();
+    const isField  = ['INPUT','TEXTAREA','SELECT'].includes(tag);
+    const isButton = tag === 'BUTTON';
+    const isAnchor = tag === 'A';
+    const isForm   = tag === 'FORM';
+
+    if (['input','change','focus','blur'].includes(event.type) && !isField) return;
+    if (event.type === 'submit' && !isForm) return;
+    if (event.type === 'click' && !isButton && !isAnchor && !t.dataset.trackClick) return;
+    if (this._isBlocked(t)) return;
+
+    const detail = {
+      eventType:  event.type,
+      timestamp:  new Date().toISOString(),
+      pageName:   this.currentPage,
+      fieldId:    t.dataset ? t.dataset.fieldId : undefined,
+      fieldType:  isField ? t.type : undefined,
+      elementTag: tag.toLowerCase()
+    };
+    if (isButton || isAnchor) detail.elementText = t.textContent.trim();
+    if (isForm) {
+      detail.fieldId = t.id || (t.dataset && t.dataset.formId);
+      this._dispatch('formSubmit', detail);
+    } else {
+      this._dispatch('fieldInteraction', detail);
+    }
+  }
+
+  _dispatch(name, detail) {
+    document.dispatchEvent(
+      new CustomEvent(this.schema.eventPrefix + name, { bubbles: true, detail })
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Navigation
+// ═══════════════════════════════════════════════════════════════════════
+const observer = new TrackingObserver(SCHEMA);
+let submittedData = null;
+
+function navigate(page) {
+  document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+  document.getElementById('page-' + page).classList.add('active');
+  document.querySelectorAll('.yb-nav button').forEach(b => b.classList.remove('active'));
+  const navMap = { landing: 'nav-home', application: 'nav-apply', confirmation: 'nav-confirm' };
+  const btn = document.getElementById(navMap[page]);
+  if (btn) btn.classList.add('active');
+  observer.setPage(page);
+  window.scrollTo(0, 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Form submission
+// ═══════════════════════════════════════════════════════════════════════
+document.getElementById('loan-form').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const v = id => document.getElementById(id).value;
+  submittedData = {
+    firstName:     v('first-name'),
+    lastName:      v('last-name'),
+    email:         v('email'),
+    phone:         v('phone'),
+    loanAmount:    v('loan-amount'),
+    loanPurpose:   v('loan-purpose'),
+    monthlyIncome: v('monthly-income')
+    // SSN, DOB, account-number intentionally omitted from summary
+  };
+
+  document.getElementById('confirm-name').textContent =
+    'Thank you, ' + (submittedData.firstName || 'applicant') + '!';
+  document.getElementById('confirm-ref').textContent =
+    'YB-' + Date.now().toString(36).toUpperCase();
+
+  const fmt = (val, prefix) => val ? prefix + Number(val).toLocaleString() : '—';
+  const rows = [
+    ['Name',          ((submittedData.firstName || '') + ' ' + (submittedData.lastName || '')).trim() || '—'],
+    ['Email',         submittedData.email         || '—'],
+    ['Phone',         submittedData.phone          || '—'],
+    ['Loan Amount',   fmt(submittedData.loanAmount, '$')],
+    ['Loan Purpose',  submittedData.loanPurpose    || '—'],
+    ['Monthly Income',fmt(submittedData.monthlyIncome, '$')]
+  ];
+  document.getElementById('confirm-summary').innerHTML =
+    rows.map(([l,v]) => `<tr><td>${l}</td><td>${v}</td></tr>`).join('');
+
+  document.getElementById('nav-confirm').style.display = '';
+  navigate('confirmation');
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Adobe SDK simulator
+//  (In production, Adobe Launch rules listen to these same events)
+// ═══════════════════════════════════════════════════════════════════════
+let eventCount = 0;
+let consoleCollapsed = false;
+const logEl = document.getElementById('sdk-log');
+const countEl = document.getElementById('sdk-count');
+const COLORS = { pageView: '#569cd6', fieldInteraction: '#4ec9b0', formSubmit: '#dcdcaa' };
+
+function addSdkEvent(eventName, detail) {
+  const color = COLORS[eventName] || '#ce9178';
+  const time  = detail.timestamp ? detail.timestamp.slice(11, 23) : '';
+  const meta  = [
+    detail.fieldId     && `fieldId="${detail.fieldId}"`,
+    detail.fieldType   && `type="${detail.fieldType}"`,
+    detail.pageName    && `page="${detail.pageName}"`,
+    detail.elementText && `text="${detail.elementText}"`
+  ].filter(Boolean).join('  ');
+
+  eventCount++;
+  const entry = document.createElement('div');
+  entry.className = 'sdk-entry';
+  entry.innerHTML =
+    `<span class="sdk-time">${time}</span>` +
+    `<span class="sdk-name" style="color:${color}">${eventName}</span>` +
+    (meta ? `<span class="sdk-meta">${meta}</span>` : '');
+
+  entry.addEventListener('click', function() {
+    const existing = this.querySelector('.sdk-detail');
+    if (existing) { existing.remove(); return; }
+    const pre = document.createElement('div');
+    pre.className = 'sdk-detail';
+    pre.textContent = JSON.stringify(detail, null, 2);
+    this.appendChild(pre);
+  });
+
+  const empty = logEl.querySelector('.sdk-empty');
+  if (empty) empty.remove();
+  logEl.insertBefore(entry, logEl.firstChild);
+  countEl.textContent = eventCount + ' event' + (eventCount !== 1 ? 's' : '') + (consoleCollapsed ? ' ▲' : ' ▼');
+}
+
+['pageView', 'fieldInteraction', 'formSubmit'].forEach(name => {
+  document.addEventListener('yourbank:' + name, e => addSdkEvent(name, e.detail));
+});
+
+function toggleConsole() {
+  consoleCollapsed = !consoleCollapsed;
+  document.getElementById('sdk-console').classList.toggle('collapsed', consoleCollapsed);
+  document.getElementById('console-spacer').style.height = (consoleCollapsed ? 36 : 260) + 'px';
+  countEl.textContent = eventCount + ' event' + (eventCount !== 1 ? 's' : '') + (consoleCollapsed ? ' ▲' : ' ▼');
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Boot
+// ═══════════════════════════════════════════════════════════════════════
+observer.start();
+observer.setPage('landing');
+</script>
+</body>
+</html>

--- a/libs/yourbank-design/TRACKING.md
+++ b/libs/yourbank-design/TRACKING.md
@@ -1,0 +1,223 @@
+# YourBank Tracking Observer — Spec & Schema Guide
+
+This document describes how the `TrackingObserver` works, how to define the
+blocking schema, and how the Adobe Web SDK integrates with custom events.
+
+---
+
+## Overview
+
+The `TrackingObserver` is a framework-agnostic class exported from
+`yourbank-design`. It:
+
+1. **Reads a schema** that declares which form fields are excluded from tracking
+2. **Stamps blocked fields** with `data-tracking-blocked="true"` via a
+   `MutationObserver` so Adobe SDK rules can natively filter them
+3. **Delegates events** (input, change, focus, blur, click, submit) at the
+   document level and drops events from blocked elements
+4. **Dispatches custom DOM events** (`yourbank:*`) that Adobe SDK rules listen
+   to — no changes to UI components required
+
+---
+
+## Schema Definition
+
+The schema is a plain TypeScript/JavaScript object (or a parsed JSON file)
+conforming to the `TrackingSchema` interface exported from `yourbank-design`:
+
+```ts
+import type { TrackingSchema } from 'yourbank-design'
+
+const schema: TrackingSchema = {
+  version: '1.0.0',
+  description: '…',
+  eventPrefix: 'yourbank:',
+  blockedFields: [
+    {
+      selector: "[data-field-id='ssn']",
+      reason: 'Social Security Number is sensitive PII',
+      category: 'sensitive_pii'
+    }
+    // …
+  ]
+}
+```
+
+### `TrackingSchema` fields
+
+| Field          | Type            | Description |
+|----------------|-----------------|-------------|
+| `version`      | `string`        | Semantic version of the schema document |
+| `description`  | `string`        | Optional human-readable description |
+| `eventPrefix`  | `string`        | Prefix for all custom DOM events (`"yourbank:"`) |
+| `blockedFields`| `BlockedField[]`| List of field exclusion rules |
+
+### `BlockedField` fields
+
+| Field      | Type                   | Description |
+|------------|------------------------|-------------|
+| `selector` | `string`               | CSS selector identifying the element(s) to block |
+| `reason`   | `string`               | Why this field is excluded (for audit trail) |
+| `category` | `BlockedFieldCategory` | Data sensitivity category (see below) |
+
+### `BlockedFieldCategory` values
+
+| Value           | When to use |
+|-----------------|-------------|
+| `sensitive_pii` | SSN, date of birth, government IDs, biometrics |
+| `credential`    | Passwords, PINs, security question answers |
+| `financial`     | Account numbers, card numbers, routing numbers |
+| `custom`        | Application-specific exclusions |
+
+---
+
+## Field Identification Convention
+
+Fields are identified by the **`data-field-id` attribute** placed on the HTML
+element. This is the recommended convention for this codebase:
+
+```html
+<!-- TRACKED — no entry in blockedFields -->
+<input type="text" data-field-id="first-name" />
+<input type="email" data-field-id="email" />
+<input type="number" data-field-id="loan-amount" />
+
+<!-- BLOCKED — matches a blockedFields selector -->
+<input type="password" data-field-id="ssn" />
+<input type="date"     data-field-id="dob" />
+<input type="password" data-field-id="account-number" />
+```
+
+The UI component code does **not** need to import the schema or know about
+Adobe. The `data-field-id` attribute is the only contract between the component
+and the tracking system.
+
+---
+
+## Blocked Fields — Quick Reference
+
+The example app's schema (`example/src/tracking-schema.ts`) blocks:
+
+| `data-field-id`  | Category        | Reason |
+|------------------|-----------------|--------|
+| `ssn`            | `sensitive_pii` | Social Security Number |
+| `password`       | `credential`    | Login / account password |
+| `dob`            | `sensitive_pii` | Date of birth (CCPA / GDPR) |
+| `account-number` | `financial`     | Bank account number |
+
+All other `data-field-id` values are **tracked by default**.
+
+---
+
+## DOM Attributes Stamped by the Observer
+
+After `observer.start()` runs, every blocked element receives:
+
+| Attribute                       | Value |
+|---------------------------------|-------|
+| `data-tracking-blocked`         | `"true"` |
+| `data-tracking-block-reason`    | The `reason` string from the schema |
+| `data-tracking-block-category`  | The `category` string from the schema |
+
+These attributes can be used:
+- By Adobe SDK rules as conditions (e.g. "Attribute `data-tracking-blocked`
+  does not equal `true`")
+- By CSS to add a visual indicator in development/QA builds
+- By automated accessibility or privacy audits
+
+---
+
+## Custom Events Dispatched
+
+The observer dispatches `CustomEvent`s on `document`. All events are prefixed
+with `eventPrefix` from the schema (default `"yourbank:"`).
+
+### `yourbank:pageView`
+
+Fired when `observer.setPage(pageName)` is called.
+
+```ts
+detail: {
+  eventType: 'pageView',
+  pageName: string,
+  timestamp: string   // ISO-8601
+}
+```
+
+### `yourbank:fieldInteraction`
+
+Fired on `input`, `change`, `focus`, `blur` events on **non-blocked** fields.
+
+```ts
+detail: {
+  eventType: 'input' | 'change' | 'focus' | 'blur',
+  fieldId?: string,    // data-field-id value
+  fieldType?: string,  // <input type="...">
+  pageName?: string,
+  timestamp: string,
+  elementTag: string   // "input" | "textarea" | "select"
+  // NOTE: field *values* are never included
+}
+```
+
+### `yourbank:formSubmit`
+
+Fired on form `submit` events where the form is **not** blocked.
+
+```ts
+detail: {
+  eventType: 'submit',
+  fieldId?: string,    // form id or data-form-id
+  pageName?: string,
+  timestamp: string,
+  elementTag: 'form'
+}
+```
+
+---
+
+## Adobe Web SDK Integration
+
+In Adobe Experience Platform Data Collection (Launch / Tags), create rules like:
+
+**Rule: Track field interaction**
+- Event: Custom Event — `yourbank:fieldInteraction`
+- Condition: Element Attribute `data-tracking-blocked` does not equal `true`
+- Action: Send Beacon — Analytics (pass `event.detail` as context data)
+
+**Rule: Track page view**
+- Event: Custom Event — `yourbank:pageView`
+- Action: Send Beacon — Page View
+
+**Rule: Track form submit**
+- Event: Custom Event — `yourbank:formSubmit`
+- Action: Send Beacon — Analytics
+
+---
+
+## Usage
+
+```ts
+import { TrackingObserver } from 'yourbank-design'
+import schema from './tracking-schema'
+
+// Typically in your app root component (e.g. index.tsx / App.tsx)
+const observer = new TrackingObserver(schema)
+observer.start()
+observer.setPage('landing')
+
+// When navigating to a new view
+observer.setPage('loan-application')
+
+// On unmount
+observer.stop()
+```
+
+---
+
+## Governance
+
+Changes to `tracking-schema.ts` (or its JSON equivalent) should be reviewed by
+**Privacy, Legal, and Analytics** teams before merging. The `reason` and
+`category` fields on each `BlockedField` entry serve as the audit trail for
+why a field is excluded.

--- a/libs/yourbank-design/TRACKING.md
+++ b/libs/yourbank-design/TRACKING.md
@@ -1,7 +1,7 @@
-# YourBank Tracking Observer — Spec & Schema Guide
+# YourBank Tracking Observer — Spec & Schema Guide (v2)
 
 This document describes how the `TrackingObserver` works, how to define the
-blocking schema, and how the Adobe Web SDK integrates with custom events.
+schema, and how analytics vendors integrate with custom events.
 
 ---
 
@@ -10,57 +10,113 @@ blocking schema, and how the Adobe Web SDK integrates with custom events.
 The `TrackingObserver` is a framework-agnostic class exported from
 `yourbank-design`. It:
 
-1. **Reads a schema** that declares which form fields are excluded from tracking
-2. **Stamps blocked fields** with `data-tracking-blocked="true"` via a
-   `MutationObserver` so Adobe SDK rules can natively filter them
-3. **Delegates events** (input, change, focus, blur, click, submit) at the
-   document level and drops events from blocked elements
-4. **Dispatches custom DOM events** (`yourbank:*`) that Adobe SDK rules listen
-   to — no changes to UI components required
+1. **Reads a schema** that declares which fields are blocked and how tracked fields should be enriched
+2. **Stamps blocked fields** with `data-tracking-blocked="true"` via a `MutationObserver` so vendor rules can natively filter them
+3. **Resolves component types** — derives a semantic type string (`input:text`, `button:submit`, etc.) for every event
+4. **Enriches event payloads** — merges static metadata from `schema.fieldMap` into events for matching fields
+5. **Filters events by component type** — only fires meaningful events per type (e.g. text inputs don't fire per-keystroke `input` events by default)
+6. **Dispatches custom DOM events** (`yourbank:*`) that any vendor can listen to — no changes to UI components required
+
+---
+
+## Architecture
+
+```
+  DOM Events (input / change / focus / blur / click / submit)
+         │  capture phase, single listener on document
+         ▼
+  ┌────────────────────────────────────────────────┐
+  │              TrackingObserver                  │
+  │                                                │
+  │  1. isBlocked?           → drop               │  ← schema.blockedFields
+  │  2. resolveComponentType()                     │  ← tag + type + data-component
+  │  3. input:hidden?        → drop               │
+  │  4. eventAllowed?        → drop if not        │  ← fieldMap.events || defaults
+  │  5. findFieldMeta()                            │  ← schema.fieldMap
+  │  6. dispatchCustomEvent()                      │
+  └─────────────────┬──────────────────────────────┘
+                    │  document.dispatchEvent(CustomEvent)
+                    │
+         ┌──────────┼──────────┬─────────────┐
+         ▼          ▼          ▼             ▼
+      Adobe        GA4      Segment      Any Vendor
+     (Launch)    (gtag)   (analytics)    (external listener)
+```
 
 ---
 
 ## Schema Definition
 
 The schema is a plain TypeScript/JavaScript object (or a parsed JSON file)
-conforming to the `TrackingSchema` interface exported from `yourbank-design`:
+conforming to the `TrackingSchema` interface exported from `yourbank-design`.
+
+### v1 — blockedFields only (still works)
 
 ```ts
 import type { TrackingSchema } from 'yourbank-design'
 
 const schema: TrackingSchema = {
   version: '1.0.0',
-  description: '…',
   eventPrefix: 'yourbank:',
   blockedFields: [
-    {
-      selector: "[data-field-id='ssn']",
-      reason: 'Social Security Number is sensitive PII',
-      category: 'sensitive_pii'
-    }
-    // …
+    { selector: "[data-field-id='ssn']", reason: 'SSN is sensitive PII', category: 'sensitive_pii' }
   ]
 }
 ```
 
-### `TrackingSchema` fields
+### v2 — blockedFields + fieldMap
 
-| Field          | Type            | Description |
-|----------------|-----------------|-------------|
-| `version`      | `string`        | Semantic version of the schema document |
-| `description`  | `string`        | Optional human-readable description |
-| `eventPrefix`  | `string`        | Prefix for all custom DOM events (`"yourbank:"`) |
-| `blockedFields`| `BlockedField[]`| List of field exclusion rules |
+```ts
+import type { TrackingSchema } from 'yourbank-design'
 
-### `BlockedField` fields
+const schema: TrackingSchema = {
+  version: '2.0.0',
+  eventPrefix: 'yourbank:',
+
+  blockedFields: [
+    { selector: "[data-field-id='ssn']",      reason: 'SSN',           category: 'sensitive_pii' },
+    { selector: "[type='password']",           reason: 'Password',      category: 'credential'    },
+    { selector: "[data-field-id='dob']",       reason: 'Date of birth', category: 'sensitive_pii' },
+    { selector: "[data-field-id='account-number']", reason: 'Account #', category: 'financial'   }
+  ],
+
+  fieldMap: [
+    {
+      selector: "[data-field-id='email']",
+      meta: { section: 'contact-info', label: 'Email Address', required: true, step: 1 }
+    },
+    {
+      selector: "[data-field-id='loan-amount']",
+      meta: { section: 'loan-details', label: 'Requested Amount', step: 2 },
+      events: ['change', 'blur']   // suppress focus events
+    }
+  ]
+}
+```
+
+---
+
+## TrackingSchema fields
+
+| Field          | Type              | Required | Description |
+|----------------|-------------------|----------|-------------|
+| `version`      | `string`          | yes      | Semantic version of the schema document |
+| `description`  | `string`          | no       | Optional human-readable description |
+| `eventPrefix`  | `string`          | yes      | Prefix for all custom DOM events (`"yourbank:"`) |
+| `blockedFields`| `BlockedField[]`  | yes      | Fields that must NEVER generate events |
+| `fieldMap`     | `FieldDefinition[]` | no     | Per-field enrichment metadata (v2) |
+
+---
+
+## BlockedField fields
 
 | Field      | Type                   | Description |
 |------------|------------------------|-------------|
 | `selector` | `string`               | CSS selector identifying the element(s) to block |
-| `reason`   | `string`               | Why this field is excluded (for audit trail) |
-| `category` | `BlockedFieldCategory` | Data sensitivity category (see below) |
+| `reason`   | `string`               | Why this field is excluded (audit trail) |
+| `category` | `BlockedFieldCategory` | Data sensitivity category |
 
-### `BlockedFieldCategory` values
+### BlockedFieldCategory values
 
 | Value           | When to use |
 |-----------------|-------------|
@@ -71,41 +127,59 @@ const schema: TrackingSchema = {
 
 ---
 
-## Field Identification Convention
+## FieldDefinition fields (v2)
 
-Fields are identified by the **`data-field-id` attribute** placed on the HTML
-element. This is the recommended convention for this codebase:
-
-```html
-<!-- TRACKED — no entry in blockedFields -->
-<input type="text" data-field-id="first-name" />
-<input type="email" data-field-id="email" />
-<input type="number" data-field-id="loan-amount" />
-
-<!-- BLOCKED — matches a blockedFields selector -->
-<input type="password" data-field-id="ssn" />
-<input type="date"     data-field-id="dob" />
-<input type="password" data-field-id="account-number" />
-```
-
-The UI component code does **not** need to import the schema or know about
-Adobe. The `data-field-id` attribute is the only contract between the component
-and the tracking system.
+| Field      | Type | Required | Description |
+|------------|------|----------|-------------|
+| `selector` | `string` | yes | CSS selector — same convention as blockedFields |
+| `meta`     | `Record<string, string \| number \| boolean>` | yes | Merged into `event.detail.meta` |
+| `events`   | `Array<'input'\|'change'\|'focus'\|'blur'\|'click'\|'submit'>` | no | Override default events for this field |
 
 ---
 
-## Blocked Fields — Quick Reference
+## Component Type Taxonomy (v2)
 
-The example app's schema (`example/src/tracking-schema.ts`) blocks:
+Every event payload includes a `componentType` string. Resolution order:
+1. `data-component` attribute (explicit override)
+2. Derived from `tagName` + `type` attribute
 
-| `data-field-id`  | Category        | Reason |
-|------------------|-----------------|--------|
-| `ssn`            | `sensitive_pii` | Social Security Number |
-| `password`       | `credential`    | Login / account password |
-| `dob`            | `sensitive_pii` | Date of birth (CCPA / GDPR) |
-| `account-number` | `financial`     | Bank account number |
+| Element | type attr | componentType | Default events |
+|---|---|---|---|
+| `<input>` | text / email / tel / search / url | `input:text` | focus, blur, change |
+| `<input>` | password | `input:password` | (always blocked) |
+| `<input>` | checkbox | `input:checkbox` | change |
+| `<input>` | radio | `input:radio` | change |
+| `<input>` | number | `input:number` | focus, blur, change |
+| `<input>` | hidden | `input:hidden` | **(never fires)** |
+| `<input>` | date / datetime-local | `input:date` | change, blur |
+| `<button>` | submit | `button:submit` | click |
+| `<button>` | button | `button:button` | click |
+| `<button>` | reset | `button:reset` | click |
+| `<select>` | — | `select` | change, focus, blur |
+| `<textarea>` | — | `textarea` | focus, blur, change |
+| `<a>` | — | `link` | click |
+| `<form>` | — | `form` | submit |
 
-All other `data-field-id` values are **tracked by default**.
+---
+
+## Field Identification Convention
+
+Fields are identified by the **`data-field-id` attribute**:
+
+```html
+<!-- TRACKED — will fire events with meta from fieldMap -->
+<input type="text"  data-field-id="first-name" />
+<input type="email" data-field-id="email" />
+<select             data-field-id="loan-purpose" />
+
+<!-- BLOCKED — observer stamps these, no events ever fire -->
+<input type="text"     data-field-id="ssn" />
+<input type="date"     data-field-id="dob" />
+<input type="password" data-field-id="password" />
+```
+
+UI components do **not** need to import the schema. The `data-field-id`
+attribute is the only contract between the component and the tracking system.
 
 ---
 
@@ -119,18 +193,9 @@ After `observer.start()` runs, every blocked element receives:
 | `data-tracking-block-reason`    | The `reason` string from the schema |
 | `data-tracking-block-category`  | The `category` string from the schema |
 
-These attributes can be used:
-- By Adobe SDK rules as conditions (e.g. "Attribute `data-tracking-blocked`
-  does not equal `true`")
-- By CSS to add a visual indicator in development/QA builds
-- By automated accessibility or privacy audits
-
 ---
 
 ## Custom Events Dispatched
-
-The observer dispatches `CustomEvent`s on `document`. All events are prefixed
-with `eventPrefix` from the schema (default `"yourbank:"`).
 
 ### `yourbank:pageView`
 
@@ -139,24 +204,26 @@ Fired when `observer.setPage(pageName)` is called.
 ```ts
 detail: {
   eventType: 'pageView',
-  pageName: string,
+  pageName:  string,
   timestamp: string   // ISO-8601
 }
 ```
 
 ### `yourbank:fieldInteraction`
 
-Fired on `input`, `change`, `focus`, `blur` events on **non-blocked** fields.
+Fired on allowed events for **non-blocked** fields.
 
 ```ts
 detail: {
-  eventType: 'input' | 'change' | 'focus' | 'blur',
-  fieldId?: string,    // data-field-id value
-  fieldType?: string,  // <input type="...">
-  pageName?: string,
-  timestamp: string,
-  elementTag: string   // "input" | "textarea" | "select"
-  // NOTE: field *values* are never included
+  eventType:     'input' | 'change' | 'focus' | 'blur' | 'click',
+  fieldId?:      string,    // data-field-id value
+  fieldType?:    string,    // <input type="...">
+  pageName?:     string,
+  timestamp:     string,
+  elementTag:    string,    // "input" | "textarea" | "select" | "button"
+  elementText?:  string,    // buttons/links only — input values never captured
+  componentType?: string,   // v2: "input:text", "button:submit", etc.
+  meta?:         Record<string, string | number | boolean>  // v2: from fieldMap
 }
 ```
 
@@ -166,32 +233,56 @@ Fired on form `submit` events where the form is **not** blocked.
 
 ```ts
 detail: {
-  eventType: 'submit',
-  fieldId?: string,    // form id or data-form-id
-  pageName?: string,
-  timestamp: string,
-  elementTag: 'form'
+  eventType:      'submit',
+  fieldId?:       string,   // form id or data-form-id
+  pageName?:      string,
+  timestamp:      string,
+  elementTag:     'form',
+  componentType?: 'form'
 }
 ```
 
 ---
 
-## Adobe Web SDK Integration
+## Vendor Integration
 
-In Adobe Experience Platform Data Collection (Launch / Tags), create rules like:
+### Adobe Web SDK (Launch / Tags)
+
+Create rules in Adobe Experience Platform Data Collection:
 
 **Rule: Track field interaction**
 - Event: Custom Event — `yourbank:fieldInteraction`
 - Condition: Element Attribute `data-tracking-blocked` does not equal `true`
-- Action: Send Beacon — Analytics (pass `event.detail` as context data)
+- Action: Send Beacon — pass `event.detail` + `event.detail.meta` as context data
 
 **Rule: Track page view**
 - Event: Custom Event — `yourbank:pageView`
 - Action: Send Beacon — Page View
 
-**Rule: Track form submit**
-- Event: Custom Event — `yourbank:formSubmit`
-- Action: Send Beacon — Analytics
+### Google Analytics 4
+
+```js
+document.addEventListener('yourbank:fieldInteraction', e => {
+  gtag('event', e.detail.componentType, {
+    field_id:   e.detail.fieldId,
+    page:       e.detail.pageName,
+    section:    e.detail.meta?.section,
+    label:      e.detail.meta?.label,
+    event_type: e.detail.eventType
+  })
+})
+```
+
+### Segment
+
+```js
+document.addEventListener('yourbank:fieldInteraction', e => {
+  analytics.track('Field Interaction', {
+    ...e.detail,
+    ...e.detail.meta
+  })
+})
+```
 
 ---
 
@@ -201,17 +292,26 @@ In Adobe Experience Platform Data Collection (Launch / Tags), create rules like:
 import { TrackingObserver } from 'yourbank-design'
 import schema from './tracking-schema'
 
-// Typically in your app root component (e.g. index.tsx / App.tsx)
 const observer = new TrackingObserver(schema)
 observer.start()
 observer.setPage('landing')
 
-// When navigating to a new view
+// SPA navigation
 observer.setPage('loan-application')
 
-// On unmount
+// Unmount
 observer.stop()
 ```
+
+---
+
+## Privacy Guarantees
+
+1. **Field values are never captured** — `el.value` is never read or included in any payload
+2. **`input:hidden` never fires** — filtered at component type resolution
+3. **Password fields are always blocked** — `[type="password"]` is covered by blockedFields
+4. **Blocked ancestor propagation** — if any parent element is blocked, all child events are dropped
+5. **`data-tracking-blocked` stamp** — applied to DOM for belt-and-suspenders vendor filtering
 
 ---
 

--- a/libs/yourbank-design/example/src/App.tsx
+++ b/libs/yourbank-design/example/src/App.tsx
@@ -4,13 +4,16 @@
  * Demonstrates:
  *  1. Form with editable fields and a submit button
  *  2. Navigation between views (Landing → Application → Confirmation)
- *  3. A DOM observer (TrackingObserver) that dispatches custom events the
- *     Adobe Web SDK can listen to
- *  4. A schema (tracking-schema.ts) that blocks specific sensitive fields from
- *     being tracked — without any changes to the form components themselves
+ *  3. A DOM observer (TrackingObserver) that dispatches custom events that
+ *     any analytics vendor can listen to
+ *  4. A schema (tracking-schema.ts) that:
+ *     - Blocks specific sensitive fields from being tracked (v1)
+ *     - Enriches tracked field events with business metadata (v2)
+ *  5. An Architecture page explaining the full system design
  *
- * The "Adobe SDK Event Console" panel at the bottom simulates what the real
- * Adobe Web SDK would receive when its rules listen to `yourbank:*` events.
+ * The "Analytics Event Console" panel at the bottom simulates what any
+ * vendor (Adobe, GA4, Segment) would receive when listening to `yourbank:*`
+ * custom events on document.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react'
@@ -21,10 +24,11 @@ import trackingSchema from './tracking-schema'
 import LandingPage from './pages/LandingPage'
 import ApplicationPage, { ApplicationFormData } from './pages/ApplicationPage'
 import ConfirmationPage from './pages/ConfirmationPage'
+import ArchitecturePage from './pages/ArchitecturePage'
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
-type Page = 'landing' | 'application' | 'confirmation'
+type Page = 'landing' | 'application' | 'confirmation' | 'architecture'
 
 interface EventLogEntry {
   id: number
@@ -33,17 +37,13 @@ interface EventLogEntry {
   blocked: boolean
 }
 
-// ─── Mock Adobe SDK ─────────────────────────────────────────────────────────
+// ─── Analytics vendor simulator ─────────────────────────────────────────────
 //
-// In a real deployment the Adobe Web SDK (alloy.js) is loaded separately and
-// configured via Adobe Experience Platform Data Collection (Launch/Tags).
-// SDK rules listen for custom events like `yourbank:fieldInteraction` and
-// fire send-beacon / analytics actions.
-//
-// Here we register the same event listeners a typical Launch rule would use,
-// and surface them in the on-page debug console below.
+// In a real deployment vendor SDKs (Adobe alloy.js, gtag.js, analytics.js) are
+// loaded separately. Each vendor registers its own document event listeners.
+// Here we simulate what any vendor would receive from the custom events.
 
-function createAdobeSDKSimulator(
+function createVendorSimulator(
   onEvent: (entry: Omit<EventLogEntry, 'id'>) => void
 ) {
   const prefix = trackingSchema.eventPrefix // 'yourbank:'
@@ -89,8 +89,8 @@ const App: React.FC = () => {
     observer.start()
     observerRef.current = observer
 
-    // Adobe SDK simulation — only sees events that passed through the observer
-    const cleanup = createAdobeSDKSimulator(addEvent)
+    // Vendor simulation — only sees events that passed through the observer
+    const cleanup = createVendorSimulator(addEvent)
 
     return () => {
       observer.stop()
@@ -98,7 +98,7 @@ const App: React.FC = () => {
     }
   }, [addEvent])
 
-  // Announce page changes to the observer so Adobe SDK rules get page context
+  // Announce page changes to the observer so vendor rules get page context
   useEffect(() => {
     observerRef.current?.setPage(page)
   }, [page])
@@ -133,6 +133,13 @@ const App: React.FC = () => {
             Confirmation
           </button>
         )}
+        <button
+          className={page === 'architecture' ? 'active' : ''}
+          onClick={() => navigateTo('architecture')}
+          style={{ marginLeft: 'auto' }}
+        >
+          Architecture
+        </button>
       </Header>
 
       <main>
@@ -151,9 +158,10 @@ const App: React.FC = () => {
             onBack={() => navigateTo('landing')}
           />
         )}
+        {page === 'architecture' && <ArchitecturePage />}
       </main>
 
-      {/* ── Adobe SDK Event Console ──────────────────────────────────────── */}
+      {/* ── Analytics Event Console ──────────────────────────────────────── */}
       <div
         style={{
           position: 'fixed',
@@ -188,9 +196,9 @@ const App: React.FC = () => {
         >
           <span>
             <span style={{ color: '#c0392b', fontWeight: 700 }}>●</span>{' '}
-            Adobe Web SDK Event Console{' '}
+            Analytics Event Console{' '}
             <span style={{ color: '#888', fontSize: 11 }}>
-              (simulated — only non-blocked fields appear here)
+              (simulated vendor listener — blocked fields never appear)
             </span>
           </span>
           <span style={{ color: '#888' }}>
@@ -200,13 +208,7 @@ const App: React.FC = () => {
         </div>
 
         {/* Event log */}
-        <div
-          style={{
-            overflowY: 'auto',
-            flex: 1,
-            padding: '4px 0'
-          }}
-        >
+        <div style={{ overflowY: 'auto', flex: 1, padding: '4px 0' }}>
           {eventLog.length === 0 && (
             <div style={{ padding: '12px 16px', color: '#666' }}>
               Interact with the form to see tracking events…
@@ -236,16 +238,31 @@ const EVENT_COLORS: Record<string, string> = {
   formSubmit: '#dcdcaa'
 }
 
+const COMPONENT_TYPE_COLORS: Record<string, string> = {
+  'input:text':     '#ce9178',
+  'input:checkbox': '#b5cea8',
+  'input:number':   '#b5cea8',
+  'input:date':     '#b5cea8',
+  'button:submit':  '#dcdcaa',
+  'button:button':  '#d7ba7d',
+  'select':         '#9cdcfe',
+  'textarea':       '#ce9178',
+  'link':           '#569cd6',
+  'form':           '#dcdcaa'
+}
+
 const EventRow: React.FC<EventRowProps> = ({ entry }) => {
   const [expanded, setExpanded] = useState(false)
   const color = EVENT_COLORS[entry.eventName] ?? '#ce9178'
   const d = entry.detail
+  const ctColor = d.componentType ? (COMPONENT_TYPE_COLORS[d.componentType] ?? '#d4d4d4') : '#d4d4d4'
 
   const summary = [
+    d.componentType && `[${d.componentType}]`,
     d.fieldId && `fieldId="${d.fieldId}"`,
-    d.fieldType && `type="${d.fieldType}"`,
     d.pageName && `page="${d.pageName}"`,
-    d.elementText && `text="${d.elementText}"`
+    d.elementText && `text="${d.elementText}"`,
+    d.meta?.section && `section="${d.meta.section}"`
   ]
     .filter(Boolean)
     .join('  ')
@@ -264,6 +281,11 @@ const EventRow: React.FC<EventRowProps> = ({ entry }) => {
         {d.timestamp ? d.timestamp.slice(11, 23) : ''}
       </span>
       <span style={{ color, fontWeight: 600 }}>{entry.eventName}</span>
+      {d.componentType && (
+        <span style={{ color: ctColor, marginLeft: 8, fontSize: 11 }}>
+          {d.componentType}
+        </span>
+      )}
       {summary && (
         <span style={{ color: '#d4d4d4', marginLeft: 12 }}>{summary}</span>
       )}

--- a/libs/yourbank-design/example/src/App.tsx
+++ b/libs/yourbank-design/example/src/App.tsx
@@ -1,10 +1,289 @@
-import React from 'react'
+/**
+ * Example App — YourBank Design System Demo
+ *
+ * Demonstrates:
+ *  1. Form with editable fields and a submit button
+ *  2. Navigation between views (Landing → Application → Confirmation)
+ *  3. A DOM observer (TrackingObserver) that dispatches custom events the
+ *     Adobe Web SDK can listen to
+ *  4. A schema (tracking-schema.ts) that blocks specific sensitive fields from
+ *     being tracked — without any changes to the form components themselves
+ *
+ * The "Adobe SDK Event Console" panel at the bottom simulates what the real
+ * Adobe Web SDK would receive when its rules listen to `yourbank:*` events.
+ */
 
-import { ExampleComponent } from 'yourbank-design'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import Header, { TrackingObserver, TrackingEventDetail } from 'yourbank-design'
 import 'yourbank-design/dist/index.css'
 
-const App = () => {
-  return <ExampleComponent text="Create React Library Example 😄" />
+import trackingSchema from './tracking-schema'
+import LandingPage from './pages/LandingPage'
+import ApplicationPage, { ApplicationFormData } from './pages/ApplicationPage'
+import ConfirmationPage from './pages/ConfirmationPage'
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+type Page = 'landing' | 'application' | 'confirmation'
+
+interface EventLogEntry {
+  id: number
+  eventName: string
+  detail: TrackingEventDetail
+  blocked: boolean
+}
+
+// ─── Mock Adobe SDK ─────────────────────────────────────────────────────────
+//
+// In a real deployment the Adobe Web SDK (alloy.js) is loaded separately and
+// configured via Adobe Experience Platform Data Collection (Launch/Tags).
+// SDK rules listen for custom events like `yourbank:fieldInteraction` and
+// fire send-beacon / analytics actions.
+//
+// Here we register the same event listeners a typical Launch rule would use,
+// and surface them in the on-page debug console below.
+
+function createAdobeSDKSimulator(
+  onEvent: (entry: Omit<EventLogEntry, 'id'>) => void
+) {
+  const prefix = trackingSchema.eventPrefix // 'yourbank:'
+
+  const handle = (eventName: string) => (e: Event) => {
+    const customEvent = e as CustomEvent<TrackingEventDetail>
+    onEvent({
+      eventName,
+      detail: customEvent.detail,
+      blocked: false // only non-blocked events reach here
+    })
+  }
+
+  const listeners: [string, EventListener][] = [
+    [`${prefix}pageView`, handle('pageView')],
+    [`${prefix}fieldInteraction`, handle('fieldInteraction')],
+    [`${prefix}formSubmit`, handle('formSubmit')]
+  ]
+
+  listeners.forEach(([type, fn]) => document.addEventListener(type, fn))
+
+  return () => listeners.forEach(([type, fn]) => document.removeEventListener(type, fn))
+}
+
+// ─── App ───────────────────────────────────────────────────────────────────
+
+let _eventId = 0
+
+const App: React.FC = () => {
+  const [page, setPage] = useState<Page>('landing')
+  const [formData, setFormData] = useState<ApplicationFormData | null>(null)
+  const [eventLog, setEventLog] = useState<EventLogEntry[]>([])
+  const [consoleOpen, setConsoleOpen] = useState(true)
+  const observerRef = useRef<TrackingObserver | null>(null)
+
+  const addEvent = useCallback((entry: Omit<EventLogEntry, 'id'>) => {
+    setEventLog(prev => [{ ...entry, id: ++_eventId }, ...prev].slice(0, 50))
+  }, [])
+
+  // Initialise the TrackingObserver once on mount
+  useEffect(() => {
+    const observer = new TrackingObserver(trackingSchema)
+    observer.start()
+    observerRef.current = observer
+
+    // Adobe SDK simulation — only sees events that passed through the observer
+    const cleanup = createAdobeSDKSimulator(addEvent)
+
+    return () => {
+      observer.stop()
+      cleanup()
+    }
+  }, [addEvent])
+
+  // Announce page changes to the observer so Adobe SDK rules get page context
+  useEffect(() => {
+    observerRef.current?.setPage(page)
+  }, [page])
+
+  const navigateTo = (next: Page) => setPage(next)
+
+  const handleSubmit = (data: ApplicationFormData) => {
+    setFormData(data)
+    navigateTo('confirmation')
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: '#f0f0f0' }}>
+      <Header>
+        <button
+          className={page === 'landing' ? 'active' : ''}
+          onClick={() => navigateTo('landing')}
+        >
+          Home
+        </button>
+        <button
+          className={page === 'application' ? 'active' : ''}
+          onClick={() => navigateTo('application')}
+        >
+          Apply Now
+        </button>
+        {formData && (
+          <button
+            className={page === 'confirmation' ? 'active' : ''}
+            onClick={() => navigateTo('confirmation')}
+          >
+            Confirmation
+          </button>
+        )}
+      </Header>
+
+      <main>
+        {page === 'landing' && (
+          <LandingPage onApply={() => navigateTo('application')} />
+        )}
+        {page === 'application' && (
+          <ApplicationPage
+            onSubmit={handleSubmit}
+            onBack={() => navigateTo('landing')}
+          />
+        )}
+        {page === 'confirmation' && formData && (
+          <ConfirmationPage
+            formData={formData}
+            onBack={() => navigateTo('landing')}
+          />
+        )}
+      </main>
+
+      {/* ── Adobe SDK Event Console ──────────────────────────────────────── */}
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: '#1e1e1e',
+          color: '#d4d4d4',
+          fontFamily: 'monospace',
+          fontSize: 12,
+          zIndex: 9999,
+          borderTop: '3px solid #c0392b',
+          maxHeight: consoleOpen ? 260 : 36,
+          transition: 'max-height 0.25s ease',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column'
+        }}
+      >
+        {/* Console header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '6px 12px',
+            background: '#2d2d2d',
+            cursor: 'pointer',
+            flexShrink: 0
+          }}
+          onClick={() => setConsoleOpen(o => !o)}
+        >
+          <span>
+            <span style={{ color: '#c0392b', fontWeight: 700 }}>●</span>{' '}
+            Adobe Web SDK Event Console{' '}
+            <span style={{ color: '#888', fontSize: 11 }}>
+              (simulated — only non-blocked fields appear here)
+            </span>
+          </span>
+          <span style={{ color: '#888' }}>
+            {eventLog.length} event{eventLog.length !== 1 ? 's' : ''}{' '}
+            {consoleOpen ? '▼' : '▲'}
+          </span>
+        </div>
+
+        {/* Event log */}
+        <div
+          style={{
+            overflowY: 'auto',
+            flex: 1,
+            padding: '4px 0'
+          }}
+        >
+          {eventLog.length === 0 && (
+            <div style={{ padding: '12px 16px', color: '#666' }}>
+              Interact with the form to see tracking events…
+            </div>
+          )}
+          {eventLog.map(entry => (
+            <EventRow key={entry.id} entry={entry} />
+          ))}
+        </div>
+      </div>
+
+      {/* Spacer so content isn't hidden behind the console */}
+      <div style={{ height: consoleOpen ? 260 : 36 }} />
+    </div>
+  )
+}
+
+// ─── Console row ──────────────────────────────────────────────────────────
+
+interface EventRowProps {
+  entry: EventLogEntry
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  pageView: '#569cd6',
+  fieldInteraction: '#4ec9b0',
+  formSubmit: '#dcdcaa'
+}
+
+const EventRow: React.FC<EventRowProps> = ({ entry }) => {
+  const [expanded, setExpanded] = useState(false)
+  const color = EVENT_COLORS[entry.eventName] ?? '#ce9178'
+  const d = entry.detail
+
+  const summary = [
+    d.fieldId && `fieldId="${d.fieldId}"`,
+    d.fieldType && `type="${d.fieldType}"`,
+    d.pageName && `page="${d.pageName}"`,
+    d.elementText && `text="${d.elementText}"`
+  ]
+    .filter(Boolean)
+    .join('  ')
+
+  return (
+    <div
+      style={{
+        padding: '3px 16px',
+        borderBottom: '1px solid #2a2a2a',
+        cursor: 'pointer',
+        lineHeight: 1.6
+      }}
+      onClick={() => setExpanded(e => !e)}
+    >
+      <span style={{ color: '#888', marginRight: 8 }}>
+        {d.timestamp ? d.timestamp.slice(11, 23) : ''}
+      </span>
+      <span style={{ color, fontWeight: 600 }}>{entry.eventName}</span>
+      {summary && (
+        <span style={{ color: '#d4d4d4', marginLeft: 12 }}>{summary}</span>
+      )}
+      {expanded && (
+        <pre
+          style={{
+            margin: '4px 0 4px 24px',
+            color: '#9cdcfe',
+            background: '#252526',
+            padding: '8px 12px',
+            borderRadius: 4,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all'
+          }}
+        >
+          {JSON.stringify(d, null, 2)}
+        </pre>
+      )}
+    </div>
+  )
 }
 
 export default App

--- a/libs/yourbank-design/example/src/pages/ApplicationPage.tsx
+++ b/libs/yourbank-design/example/src/pages/ApplicationPage.tsx
@@ -1,0 +1,316 @@
+import React, { useState } from 'react'
+import { Container, Card, Button, Input, Select, Label, FormGroup } from 'yourbank-design'
+
+export interface ApplicationFormData {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+  dob: string          // blocked in schema
+  ssn: string          // blocked in schema
+  loanAmount: string
+  loanPurpose: string
+  monthlyIncome: string
+  accountNumber: string // blocked in schema
+}
+
+interface ApplicationPageProps {
+  onSubmit: (data: ApplicationFormData) => void
+  onBack: () => void
+}
+
+const INITIAL: ApplicationFormData = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  phone: '',
+  dob: '',
+  ssn: '',
+  loanAmount: '',
+  loanPurpose: '',
+  monthlyIncome: '',
+  accountNumber: ''
+}
+
+const ApplicationPage: React.FC<ApplicationPageProps> = ({ onSubmit, onBack }) => {
+  const [form, setForm] = useState<ApplicationFormData>(INITIAL)
+
+  const update =
+    (field: keyof ApplicationFormData) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+      setForm(prev => ({ ...prev, [field]: e.target.value }))
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    onSubmit(form)
+  }
+
+  return (
+    <Container>
+      <Card headerTitle='Loan Application'>
+        <p style={{ color: '#666', marginBottom: 24, textAlign: 'left' }}>
+          Fields marked with a lock icon (
+          <span role='img' aria-label='lock'>
+            🔒
+          </span>
+          ) are <strong>protected fields</strong>: the Adobe Web SDK tracking
+          observer will suppress all events on these inputs. No changes to this
+          form were needed — the{' '}
+          <code style={{ background: '#f0f0f0', padding: '1px 4px', borderRadius: 3 }}>
+            data-field-id
+          </code>{' '}
+          attribute on each input is all the schema needs to identify them.
+        </p>
+
+        <form
+          id='loan-application'
+          data-form-id='loan-application'
+          onSubmit={handleSubmit}
+          style={{ textAlign: 'left' }}
+        >
+          {/* ── Personal Information ── */}
+          <div className='form-section'>
+            <p
+              style={{
+                fontWeight: 700,
+                color: '#c0392b',
+                textTransform: 'uppercase',
+                fontSize: 13,
+                letterSpacing: '0.5px',
+                borderBottom: '2px solid #e8e8e8',
+                paddingBottom: 8,
+                marginBottom: 20
+              }}
+            >
+              Personal Information
+            </p>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px' }}>
+              <FormGroup>
+                <Label htmlFor='first-name' required>
+                  First Name
+                </Label>
+                {/* data-field-id="first-name" → TRACKED */}
+                <Input
+                  id='first-name'
+                  data-field-id='first-name'
+                  type='text'
+                  autoComplete='given-name'
+                  value={form.firstName}
+                  onChange={update('firstName')}
+                  placeholder='Jane'
+                  required
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='last-name' required>
+                  Last Name
+                </Label>
+                {/* data-field-id="last-name" → TRACKED */}
+                <Input
+                  id='last-name'
+                  data-field-id='last-name'
+                  type='text'
+                  autoComplete='family-name'
+                  value={form.lastName}
+                  onChange={update('lastName')}
+                  placeholder='Smith'
+                  required
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='email' required>
+                  Email
+                </Label>
+                {/* data-field-id="email" → TRACKED */}
+                <Input
+                  id='email'
+                  data-field-id='email'
+                  type='email'
+                  autoComplete='email'
+                  value={form.email}
+                  onChange={update('email')}
+                  placeholder='jane@example.com'
+                  required
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='phone'>Phone</Label>
+                {/* data-field-id="phone" → TRACKED */}
+                <Input
+                  id='phone'
+                  data-field-id='phone'
+                  type='tel'
+                  autoComplete='tel'
+                  value={form.phone}
+                  onChange={update('phone')}
+                  placeholder='(555) 000-0000'
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='dob' required>
+                  Date of Birth{' '}
+                  <span role='img' aria-label='protected field'>
+                    🔒
+                  </span>
+                </Label>
+                {/* data-field-id="dob" → BLOCKED: sensitive_pii
+                    The TrackingObserver stamps this element with
+                    data-tracking-blocked="true" — no code change required here. */}
+                <Input
+                  id='dob'
+                  data-field-id='dob'
+                  type='date'
+                  autoComplete='bday'
+                  value={form.dob}
+                  onChange={update('dob')}
+                  required
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='ssn' required>
+                  Social Security Number{' '}
+                  <span role='img' aria-label='protected field'>
+                    🔒
+                  </span>
+                </Label>
+                {/* data-field-id="ssn" → BLOCKED: sensitive_pii */}
+                <Input
+                  id='ssn'
+                  data-field-id='ssn'
+                  type='password'
+                  autoComplete='off'
+                  value={form.ssn}
+                  onChange={update('ssn')}
+                  placeholder='XXX-XX-XXXX'
+                  required
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          {/* ── Loan Details ── */}
+          <div className='form-section' style={{ marginTop: 32 }}>
+            <p
+              style={{
+                fontWeight: 700,
+                color: '#c0392b',
+                textTransform: 'uppercase',
+                fontSize: 13,
+                letterSpacing: '0.5px',
+                borderBottom: '2px solid #e8e8e8',
+                paddingBottom: 8,
+                marginBottom: 20
+              }}
+            >
+              Loan Details
+            </p>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px' }}>
+              <FormGroup>
+                <Label htmlFor='loan-amount' required>
+                  Requested Amount ($)
+                </Label>
+                {/* data-field-id="loan-amount" → TRACKED */}
+                <Input
+                  id='loan-amount'
+                  data-field-id='loan-amount'
+                  type='number'
+                  min='1000'
+                  max='100000'
+                  step='500'
+                  value={form.loanAmount}
+                  onChange={update('loanAmount')}
+                  placeholder='25000'
+                  required
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='loan-purpose' required>
+                  Loan Purpose
+                </Label>
+                {/* data-field-id="loan-purpose" → TRACKED */}
+                <Select
+                  id='loan-purpose'
+                  data-field-id='loan-purpose'
+                  value={form.loanPurpose}
+                  onChange={update('loanPurpose')}
+                  required
+                >
+                  <option value=''>Select a purpose…</option>
+                  <option value='home-improvement'>Home Improvement</option>
+                  <option value='debt-consolidation'>Debt Consolidation</option>
+                  <option value='auto'>Auto Purchase</option>
+                  <option value='education'>Education</option>
+                  <option value='business'>Small Business</option>
+                  <option value='other'>Other</option>
+                </Select>
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='monthly-income' required>
+                  Monthly Gross Income ($)
+                </Label>
+                {/* data-field-id="monthly-income" → TRACKED */}
+                <Input
+                  id='monthly-income'
+                  data-field-id='monthly-income'
+                  type='number'
+                  min='0'
+                  value={form.monthlyIncome}
+                  onChange={update('monthlyIncome')}
+                  placeholder='5000'
+                  required
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <Label htmlFor='account-number' required>
+                  YourBank Account Number{' '}
+                  <span role='img' aria-label='protected field'>
+                    🔒
+                  </span>
+                </Label>
+                {/* data-field-id="account-number" → BLOCKED: financial */}
+                <Input
+                  id='account-number'
+                  data-field-id='account-number'
+                  type='password'
+                  autoComplete='off'
+                  value={form.accountNumber}
+                  onChange={update('accountNumber')}
+                  placeholder='Account number'
+                  required
+                />
+              </FormGroup>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginTop: 32,
+              gap: 16
+            }}
+          >
+            <Button type='button' variant='secondary' onClick={onBack}>
+              Back
+            </Button>
+            <Button type='submit' variant='primary'>
+              Submit Application
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </Container>
+  )
+}
+
+export default ApplicationPage

--- a/libs/yourbank-design/example/src/pages/ArchitecturePage.tsx
+++ b/libs/yourbank-design/example/src/pages/ArchitecturePage.tsx
@@ -1,0 +1,474 @@
+import React, { useState } from 'react'
+import { Container, Card } from 'yourbank-design'
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const pre: React.CSSProperties = {
+  background: '#1e1e1e',
+  color: '#d4d4d4',
+  fontFamily: 'monospace',
+  fontSize: 12,
+  padding: '16px',
+  borderRadius: 6,
+  overflowX: 'auto',
+  margin: 0,
+  lineHeight: 1.6,
+  whiteSpace: 'pre'
+}
+
+const h2: React.CSSProperties = {
+  fontSize: 20,
+  fontWeight: 700,
+  margin: '0 0 12px',
+  color: '#1a1a2e'
+}
+
+const h3: React.CSSProperties = {
+  fontSize: 15,
+  fontWeight: 600,
+  margin: '20px 0 8px',
+  color: '#c0392b'
+}
+
+const p: React.CSSProperties = {
+  margin: '0 0 12px',
+  lineHeight: 1.7,
+  color: '#444'
+}
+
+const table: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 13,
+  fontFamily: 'monospace'
+}
+
+const th: React.CSSProperties = {
+  background: '#2d2d2d',
+  color: '#d4d4d4',
+  padding: '6px 12px',
+  textAlign: 'left',
+  fontWeight: 600,
+  borderBottom: '2px solid #444'
+}
+
+const td: React.CSSProperties = {
+  padding: '5px 12px',
+  borderBottom: '1px solid #eee',
+  verticalAlign: 'top'
+}
+
+const tdCode: React.CSSProperties = {
+  ...td,
+  fontFamily: 'monospace',
+  color: '#c0392b'
+}
+
+const badge = (color: string): React.CSSProperties => ({
+  display: 'inline-block',
+  background: color,
+  color: '#fff',
+  borderRadius: 4,
+  padding: '1px 7px',
+  fontSize: 11,
+  fontWeight: 600
+})
+
+// ─── Collapsible section ─────────────────────────────────────────────────────
+
+const Section: React.FC<{ title: string; children: React.ReactNode; defaultOpen?: boolean }> = ({
+  title, children, defaultOpen = true
+}) => {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <div
+        onClick={() => setOpen(o => !o)}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          cursor: 'pointer', padding: '10px 0', borderBottom: '2px solid #e0e0e0',
+          marginBottom: open ? 16 : 0
+        }}
+      >
+        <h2 style={{ ...h2, margin: 0 }}>{title}</h2>
+        <span style={{ color: '#888', fontSize: 18 }}>{open ? '▲' : '▼'}</span>
+      </div>
+      {open && children}
+    </div>
+  )
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+const ArchitecturePage: React.FC = () => {
+  return (
+    <Container>
+      {/* ── Hero ──────────────────────────────────────────────────────────── */}
+      <Card
+        headerTitle="Analytics Event System — Architecture"
+        style={{ marginBottom: 24 }}
+      >
+        <p style={p}>
+          This system lets any analytics vendor (Adobe, GA4, Segment, etc.) receive
+          structured interaction events from a React application — <strong>without
+          wiring vendor code into components</strong>. The app never imports Adobe SDK
+          or gtag. Vendors listen externally via standard DOM <code>CustomEvent</code>s.
+        </p>
+        <p style={{ ...p, margin: 0 }}>
+          Privacy is enforced by a <strong>schema</strong> that teams own and review.
+          Sensitive fields (SSN, DOB, passwords, account numbers) are stamped{' '}
+          <code>data-tracking-blocked="true"</code> at runtime — no component changes needed.
+        </p>
+      </Card>
+
+      {/* ── Architecture Diagram ──────────────────────────────────────────── */}
+      <Section title="Architecture">
+        <pre style={pre}>{`
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                         React App                               │
+  │                                                                 │
+  │   <Input data-field-id="email" />   ← no vendor imports        │
+  │   <Input data-field-id="ssn"   />   ← no vendor imports        │
+  │   <Button type="submit" />          ← no vendor imports        │
+  │                                                                 │
+  └────────────────────────┬────────────────────────────────────────┘
+                           │  DOM events bubble up
+                           │  (input, change, focus, blur, click, submit)
+                           ▼
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                    TrackingObserver                             │
+  │                                                                 │
+  │  1. isBlocked?  ──→ drop event        ← schema.blockedFields   │
+  │  2. resolveComponentType()            ← tag + type attribute   │
+  │  3. filterByAllowedEvents()           ← schema.fieldMap.events │
+  │  4. enrichPayload()                   ← schema.fieldMap.meta   │
+  │  5. dispatchCustomEvent()                                       │
+  │                                                                 │
+  └────────────────────────┬────────────────────────────────────────┘
+                           │  document.dispatchEvent(CustomEvent)
+                           │  e.g. "yourbank:fieldInteraction"
+                           │
+           ┌───────────────┼───────────────┬─────────────────┐
+           ▼               ▼               ▼                 ▼
+      ┌─────────┐   ┌────────────┐  ┌──────────┐   ┌──────────────┐
+      │  Adobe  │   │    GA4     │  │ Segment  │   │  Any Vendor  │
+      │  Launch │   │  (gtag)    │  │(analytics│   │              │
+      │  Rules  │   │            │  │   .js)   │   │              │
+      └─────────┘   └────────────┘  └──────────┘   └──────────────┘
+      external      external        external        external
+      listener      listener        listener        listener
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                   TrackingSchema (JSON/TS)                      │
+  │                                                                 │
+  │  blockedFields: [                                               │
+  │    { selector: "[data-field-id='ssn']", category: 'pii' }      │
+  │    { selector: "[type='password']",     category: 'credential'} │
+  │  ]                                                              │
+  │                                                                 │
+  │  fieldMap: [                                                    │
+  │    { selector: "[data-field-id='email']",                       │
+  │      meta: { section: 'contact', label: 'Email', step: 1 } }   │
+  │  ]                                                              │
+  └─────────────────────────────────────────────────────────────────┘
+`}</pre>
+      </Section>
+
+      {/* ── Component Types ───────────────────────────────────────────────── */}
+      <Section title="Component Type Taxonomy">
+        <p style={p}>
+          Every event payload includes a <code>componentType</code> string derived
+          from the element's tag and <code>type</code> attribute. This is more
+          semantic than the raw tag — vendors can route and filter on it.
+          Override it with <code>data-component="custom-name"</code>.
+        </p>
+        <table style={table}>
+          <thead>
+            <tr>
+              <th style={th}>Element</th>
+              <th style={th}>type attr</th>
+              <th style={th}>componentType</th>
+              <th style={th}>Default events fired</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ['<input>', 'text / email / tel / search / url', 'input:text', 'focus, blur, change'],
+              ['<input>', 'password', 'input:password', '(always blocked)'],
+              ['<input>', 'checkbox', 'input:checkbox', 'change'],
+              ['<input>', 'radio', 'input:radio', 'change'],
+              ['<input>', 'number', 'input:number', 'focus, blur, change'],
+              ['<input>', 'hidden', 'input:hidden', '(never fires)'],
+              ['<input>', 'date / datetime-local', 'input:date', 'change, blur'],
+              ['<button>', 'submit', 'button:submit', 'click'],
+              ['<button>', 'button', 'button:button', 'click'],
+              ['<button>', 'reset', 'button:reset', 'click'],
+              ['<select>', '—', 'select', 'change, focus, blur'],
+              ['<textarea>', '—', 'textarea', 'focus, blur, change'],
+              ['<a>', '—', 'link', 'click'],
+              ['<form>', '—', 'form', 'submit'],
+            ].map(([el, type, ct, events]) => (
+              <tr key={ct}>
+                <td style={tdCode}>{el}</td>
+                <td style={tdCode}>{type}</td>
+                <td style={{ ...tdCode, color: '#27ae60', fontWeight: 600 }}>{ct}</td>
+                <td style={{ ...td, color: ct === 'input:hidden' || type === 'password' ? '#c0392b' : '#555' }}>
+                  {events}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p style={{ ...p, marginTop: 12, fontSize: 12, color: '#888' }}>
+          The <code>events</code> array in a <code>fieldMap</code> entry overrides the defaults above
+          for that specific field. Example: <code>events: ['change', 'blur']</code> on a number
+          input suppresses <code>focus</code> to reduce noise.
+        </p>
+      </Section>
+
+      {/* ── Schema v2 ─────────────────────────────────────────────────────── */}
+      <Section title="Schema v2 Structure">
+        <p style={p}>
+          The schema is a plain TypeScript/JSON object consumed by <code>TrackingObserver</code>.
+          It has two sections: <code>blockedFields</code> (v1, required) and
+          <code>fieldMap</code> (v2, optional).
+        </p>
+        <pre style={pre}>{`import type { TrackingSchema } from 'yourbank-design'
+
+const schema: TrackingSchema = {
+  version: '2.0.0',
+  eventPrefix: 'yourbank:',
+
+  // ── v1: Fields that NEVER fire events ──────────────────────────────
+  blockedFields: [
+    {
+      selector: "[data-field-id='ssn']",
+      reason:   'Social Security Number — sensitive PII',
+      category: 'sensitive_pii'
+    },
+    {
+      selector: "[type='password']",
+      reason:   'Password — credential, never track',
+      category: 'credential'
+    }
+  ],
+
+  // ── v2: Per-field enrichment + optional event filter ────────────────
+  fieldMap: [
+    {
+      selector: "[data-field-id='email']",
+      meta: {
+        section:  'contact-info',   // business context
+        label:    'Email Address',  // human-readable name
+        required: true,             // form validation state
+        step:     1                 // wizard step number
+      }
+      // events: omitted → uses default for componentType (focus, blur, change)
+    },
+    {
+      selector: "[data-field-id='loan-amount']",
+      meta: { section: 'loan-details', label: 'Requested Amount', step: 2 },
+      events: ['change', 'blur']   // suppress focus to reduce noise
+    }
+  ]
+}`}</pre>
+
+        <h3 style={h3}>FieldDefinition interface</h3>
+        <pre style={pre}>{`interface FieldDefinition {
+  selector: string                                    // CSS selector
+  meta:     Record<string, string | number | boolean> // merged into event.detail.meta
+  events?:  Array<'input'|'change'|'focus'|'blur'|'click'|'submit'>
+}`}</pre>
+
+        <h3 style={h3}>Backward compatibility</h3>
+        <p style={{ ...p, margin: 0 }}>
+          V1 schemas (no <code>fieldMap</code>) continue to work without changes.
+          <code>meta</code> and <code>componentType</code> will simply be{' '}
+          <code>undefined</code> in event payloads.
+        </p>
+      </Section>
+
+      {/* ── Event Payloads ────────────────────────────────────────────────── */}
+      <Section title="Event Payloads">
+        <p style={p}>
+          Three custom events are dispatched on <code>document</code>. All are prefixed
+          with <code>eventPrefix</code> from the schema.
+        </p>
+
+        <h3 style={h3}>yourbank:fieldInteraction — text input blur</h3>
+        <pre style={pre}>{`{
+  "eventType":     "blur",
+  "timestamp":     "2026-03-11T14:23:01.000Z",
+  "pageName":      "loan-application",
+  "fieldId":       "email",
+  "fieldType":     "text",
+  "elementTag":    "input",
+  "componentType": "input:text",         // ← v2: design system type
+  "meta": {                              // ← v2: from schema fieldMap
+    "section":  "contact-info",
+    "label":    "Email Address",
+    "required": true,
+    "step":     1
+  }
+}`}</pre>
+
+        <h3 style={h3}>yourbank:fieldInteraction — submit button click</h3>
+        <pre style={pre}>{`{
+  "eventType":     "click",
+  "timestamp":     "2026-03-11T14:23:45.000Z",
+  "pageName":      "loan-application",
+  "elementTag":    "button",
+  "elementText":   "Submit Application",
+  "componentType": "button:submit",
+  "meta": {
+    "label": "Submit Application",
+    "flow":  "loan-application"
+  }
+}`}</pre>
+
+        <h3 style={h3}>yourbank:pageView</h3>
+        <pre style={pre}>{`{
+  "eventType": "pageView",
+  "pageName":  "loan-application",
+  "timestamp": "2026-03-11T14:22:00.000Z"
+}`}</pre>
+      </Section>
+
+      {/* ── Vendor Integration ────────────────────────────────────────────── */}
+      <Section title="Vendor Integration">
+        <p style={p}>
+          Vendors listen to <code>CustomEvent</code>s on <code>document</code>.
+          No app code changes are required per vendor — they wire themselves up externally.
+        </p>
+
+        <h3 style={h3}>Adobe Web SDK (Launch / Tags)</h3>
+        <p style={p}>
+          In Adobe Experience Platform Data Collection, create rules:
+        </p>
+        <pre style={pre}>{`// Rule: Track field interaction
+// Event:     Custom Event → "yourbank:fieldInteraction"
+// Condition: Element attribute data-tracking-blocked ≠ "true"
+// Action:    Send beacon — pass event.detail + event.detail.meta as context data
+
+// Rule: Track page view
+// Event:  Custom Event → "yourbank:pageView"
+// Action: Send beacon — page view`}</pre>
+
+        <h3 style={h3}>Google Analytics 4</h3>
+        <pre style={pre}>{`document.addEventListener('yourbank:fieldInteraction', e => {
+  gtag('event', e.detail.componentType, {
+    field_id:   e.detail.fieldId,
+    page:       e.detail.pageName,
+    section:    e.detail.meta?.section,
+    label:      e.detail.meta?.label,
+    event_type: e.detail.eventType
+  })
+})
+
+document.addEventListener('yourbank:pageView', e => {
+  gtag('event', 'page_view', { page_title: e.detail.pageName })
+})`}</pre>
+
+        <h3 style={h3}>Segment</h3>
+        <pre style={pre}>{`document.addEventListener('yourbank:fieldInteraction', e => {
+  analytics.track('Field Interaction', {
+    ...e.detail,
+    ...e.detail.meta   // section, label, step etc. promoted to top level
+  })
+})
+
+document.addEventListener('yourbank:formSubmit', e => {
+  analytics.track('Form Submitted', { formId: e.detail.fieldId })
+})`}</pre>
+      </Section>
+
+      {/* ── Privacy Guarantees ────────────────────────────────────────────── */}
+      <Section title="Privacy Guarantees">
+        <p style={p}>
+          The following rules are enforced unconditionally by the observer — they
+          cannot be overridden by schema configuration.
+        </p>
+        <table style={table}>
+          <thead>
+            <tr>
+              <th style={th}>Guarantee</th>
+              <th style={th}>How enforced</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ['Field values are never captured', 'el.value is never read or included in any payload'],
+              ['input:hidden never fires events', 'Short-circuited at component type resolution'],
+              ['Blocked ancestor propagation', 'Observer walks up the DOM tree — if any ancestor is blocked, all child events are dropped'],
+              ['data-tracking-blocked stamp', 'Applied to DOM so vendor rules (e.g. Adobe Launch conditions) can filter independently'],
+              ['Blocked fields always excluded', 'blockedFields are checked before fieldMap — a field cannot be both blocked and enriched'],
+            ].map(([g, h]) => (
+              <tr key={g}>
+                <td style={{ ...td, fontWeight: 600, color: '#1a1a2e' }}>
+                  <span style={badge('#c0392b')}>guaranteed</span>{' '}{g}
+                </td>
+                <td style={td}>{h}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Section>
+
+      {/* ── Data Flow ─────────────────────────────────────────────────────── */}
+      <Section title="Data Flow — Step by Step" defaultOpen={false}>
+        <ol style={{ lineHeight: 2, paddingLeft: 24, color: '#444' }}>
+          <li><strong>App mounts</strong> → <code>new TrackingObserver(schema).start()</code></li>
+          <li><strong>Observer walks DOM</strong> → stamps <code>data-tracking-blocked="true"</code> on all elements matching <code>blockedFields</code> selectors</li>
+          <li><strong>MutationObserver</strong> watches for new DOM nodes (React renders) → stamps them immediately</li>
+          <li><strong>User interacts</strong> with a field → DOM event bubbles to <code>document</code></li>
+          <li><strong>Observer catches it</strong> in capture phase → checks if target or ancestor is blocked → drops if so</li>
+          <li><strong>Resolves componentType</strong> from tag + type → drops if <code>input:hidden</code></li>
+          <li><strong>Checks allowed events</strong> for this field → uses <code>fieldMap[].events</code> override or defaults for componentType → drops if event not in list</li>
+          <li><strong>Looks up fieldMap</strong> for matching selector → extracts <code>meta</code></li>
+          <li><strong>Builds payload</strong> with componentType + meta merged in</li>
+          <li><strong>Dispatches CustomEvent</strong> on document (e.g. <code>yourbank:fieldInteraction</code>)</li>
+          <li><strong>Vendor listeners</strong> receive it and forward to their analytics backends</li>
+        </ol>
+      </Section>
+
+      {/* ── Usage ─────────────────────────────────────────────────────────── */}
+      <Section title="Usage" defaultOpen={false}>
+        <pre style={pre}>{`import { TrackingObserver } from 'yourbank-design'
+import schema from './tracking-schema'
+
+// Typically in your app root (index.tsx or App.tsx)
+const observer = new TrackingObserver(schema)
+observer.start()
+observer.setPage('home')
+
+// On SPA navigation / wizard step change
+observer.setPage('loan-application')
+
+// On unmount
+observer.stop()`}</pre>
+
+        <h3 style={h3}>Marking fields in JSX</h3>
+        <pre style={pre}>{`// TRACKED — will fire events with meta from fieldMap
+<Input type="text"  data-field-id="email"   />
+<Input type="tel"   data-field-id="phone"   />
+<Select             data-field-id="loan-purpose" />
+
+// BLOCKED — observer stamps these, no events ever fire
+<Input type="text"     data-field-id="ssn"            />
+<Input type="date"     data-field-id="dob"            />
+<Input type="text"     data-field-id="account-number" />
+<Input type="password" data-field-id="password"       />`}</pre>
+
+        <h3 style={h3}>Governance</h3>
+        <p style={{ ...p, margin: 0 }}>
+          Changes to <code>tracking-schema.ts</code> (or its JSON equivalent) should be
+          reviewed by <strong>Privacy, Legal, and Analytics</strong> before merging.
+          The <code>reason</code> and <code>category</code> fields on each blocked entry
+          serve as the audit trail.
+        </p>
+      </Section>
+    </Container>
+  )
+}
+
+export default ArchitecturePage

--- a/libs/yourbank-design/example/src/pages/ConfirmationPage.tsx
+++ b/libs/yourbank-design/example/src/pages/ConfirmationPage.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { Container, Card, Button, Icon } from 'yourbank-design'
+import { ApplicationFormData } from './ApplicationPage'
+
+interface ConfirmationPageProps {
+  formData: ApplicationFormData
+  onBack: () => void
+}
+
+const ConfirmationPage: React.FC<ConfirmationPageProps> = ({ formData, onBack }) => {
+  const referenceNumber = `YB-${Date.now().toString(36).toUpperCase()}`
+
+  return (
+    <Container>
+      <Card
+        headerTitle='Application Submitted'
+        headerIcon={
+          <Icon icon='dollar' color='red' style={{ width: 40, height: 40 }} />
+        }
+      >
+        <div style={{ textAlign: 'center', padding: '20px 0' }}>
+          <div
+            style={{
+              width: 72,
+              height: 72,
+              borderRadius: '50%',
+              background: '#e8f5e9',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              margin: '0 auto 20px',
+              fontSize: 36
+            }}
+          >
+            ✓
+          </div>
+          <h3 style={{ color: '#2e7d32', margin: '0 0 8px' }}>
+            Thank you, {formData.firstName}!
+          </h3>
+          <p style={{ color: '#666', margin: '0 0 24px' }}>
+            Your loan application has been received and is under review.
+          </p>
+          <div
+            style={{
+              background: '#f7f7f7',
+              border: '1px solid #e0e0e0',
+              borderRadius: 6,
+              padding: '16px 24px',
+              display: 'inline-block',
+              marginBottom: 32
+            }}
+          >
+            <span style={{ fontSize: 12, color: '#888', textTransform: 'uppercase' }}>
+              Reference Number
+            </span>
+            <br />
+            <strong style={{ fontSize: 20, letterSpacing: 2 }}>{referenceNumber}</strong>
+          </div>
+        </div>
+
+        {/* Summary — blocked fields are intentionally omitted */}
+        <div
+          style={{
+            background: '#fafafa',
+            border: '1px solid #e8e8e8',
+            borderRadius: 6,
+            padding: '20px 24px',
+            textAlign: 'left',
+            marginBottom: 24
+          }}
+        >
+          <p
+            style={{
+              fontWeight: 700,
+              color: '#c0392b',
+              textTransform: 'uppercase',
+              fontSize: 12,
+              letterSpacing: '0.5px',
+              marginBottom: 16
+            }}
+          >
+            Application Summary
+          </p>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <tbody>
+              {[
+                ['Name', `${formData.firstName} ${formData.lastName}`],
+                ['Email', formData.email],
+                ['Phone', formData.phone || '—'],
+                ['Loan Amount', formData.loanAmount ? `$${Number(formData.loanAmount).toLocaleString()}` : '—'],
+                ['Loan Purpose', formData.loanPurpose || '—'],
+                ['Monthly Income', formData.monthlyIncome ? `$${Number(formData.monthlyIncome).toLocaleString()}` : '—']
+              ].map(([label, value]) => (
+                <tr key={label}>
+                  <td
+                    style={{
+                      padding: '6px 0',
+                      color: '#888',
+                      fontSize: 13,
+                      width: '40%',
+                      borderBottom: '1px solid #f0f0f0'
+                    }}
+                  >
+                    {label}
+                  </td>
+                  <td
+                    style={{
+                      padding: '6px 0',
+                      color: '#333',
+                      fontWeight: 500,
+                      borderBottom: '1px solid #f0f0f0'
+                    }}
+                  >
+                    {value}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p
+            style={{
+              fontSize: 12,
+              color: '#999',
+              marginTop: 12,
+              marginBottom: 0
+            }}
+          >
+            🔒 Protected fields (SSN, Date of Birth, Account Number) are not
+            displayed for security.
+          </p>
+        </div>
+
+        <div style={{ textAlign: 'center' }}>
+          <Button variant='primary' onClick={onBack}>
+            Back to Home
+          </Button>
+        </div>
+      </Card>
+    </Container>
+  )
+}
+
+export default ConfirmationPage

--- a/libs/yourbank-design/example/src/pages/LandingPage.tsx
+++ b/libs/yourbank-design/example/src/pages/LandingPage.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import {
+  Container,
+  Card,
+  Button,
+  Icon,
+  LogoComponent
+} from 'yourbank-design'
+
+interface LandingPageProps {
+  onApply: () => void
+}
+
+const LandingPage: React.FC<LandingPageProps> = ({ onApply }) => {
+  return (
+    <Container>
+      <Container useCardStyle={true}>
+        <Card
+          headerTitle='YourMoney'
+          underHeaderIcon={
+            <Icon icon='money' color='red' style={{ height: '88px', width: '88px' }} />
+          }
+          footer={
+            <Button variant='primary' onClick={onApply}>
+              Get Started
+            </Button>
+          }
+        >
+          <p>We can help you move money. Anywhere, Anytime.</p>
+        </Card>
+
+        <Card
+          headerTitle='YourLoans'
+          underHeaderIcon={
+            <Icon icon='building' color='red' style={{ height: '88px', width: '88px' }} />
+          }
+          footer={
+            <Button variant='primary' onClick={onApply}>
+              Apply Now
+            </Button>
+          }
+        >
+          <p>We can help you get and manage credit.</p>
+        </Card>
+
+        <Card
+          headerTitle='YourRelationship'
+          underHeaderIcon={
+            <LogoComponent style={{ width: '88px', height: '88px', color: 'red' }} />
+          }
+          footer={
+            <Button variant='primary' onClick={onApply}>
+              Get Started
+            </Button>
+          }
+        >
+          <p>We're in this together.</p>
+        </Card>
+
+        <Card
+          headerTitle='YourInsights'
+          underHeaderIcon={
+            <Icon icon='chart' color='red' style={{ height: '88px', width: '88px' }} />
+          }
+          footer={
+            <Button variant='primary' onClick={onApply}>
+              Get Started
+            </Button>
+          }
+        >
+          <p>We can help you find your next big thing.</p>
+        </Card>
+      </Container>
+
+      <Container>
+        <Card
+          headerTitle='About Us'
+          underHeaderIcon={
+            <Icon icon='building' color='red' style={{ height: '88px', width: '88px' }} />
+          }
+          footer={<Button variant='secondary'>Learn More</Button>}
+        >
+          <p>Learn who we are, and why we care so much about you.</p>
+        </Card>
+
+        <Card
+          headerTitle='Invest'
+          underHeaderIcon={
+            <Icon icon='dollar' color='red' style={{ height: '88px', width: '88px' }} />
+          }
+          footer={<Button variant='secondary'>Learn More</Button>}
+        >
+          <p>YourBank — it's not just how we operate, it's how we're owned.</p>
+        </Card>
+      </Container>
+    </Container>
+  )
+}
+
+export default LandingPage

--- a/libs/yourbank-design/example/src/tracking-schema.ts
+++ b/libs/yourbank-design/example/src/tracking-schema.ts
@@ -1,8 +1,14 @@
 /**
- * tracking-schema.ts
+ * tracking-schema.ts — v2
  *
- * This file is the canonical source of truth for which form fields are
- * excluded from Adobe Web SDK event tracking in the YourBank example app.
+ * This file is the canonical source of truth for field tracking governance
+ * in the YourBank example app.
+ *
+ * V2 ADDITIONS
+ * ────────────
+ * fieldMap: per-field enrichment metadata merged into event payloads.
+ * Each entry maps a CSS selector to business context (section, label, step, etc.)
+ * Teams can also restrict which events fire per field via the `events` property.
  *
  * HOW TO IDENTIFY BLOCKED FIELDS
  * ──────────────────────────────
@@ -12,7 +18,7 @@
  *   <input type="text" data-field-id="first-name" />   ← TRACKED
  *   <input type="password" data-field-id="password" /> ← BLOCKED (see below)
  *
- * UI components do not need to import this schema or know about Adobe.
+ * UI components do not need to import this schema or know about any vendor.
  * The TrackingObserver reads the schema and stamps blocked elements with
  * `data-tracking-blocked="true"` at runtime.
  *
@@ -21,32 +27,27 @@
  * Changes to this file should be reviewed by Privacy, Legal, and Analytics
  * before merging. The `reason` and `category` fields document *why* a field
  * is blocked so reviewers can quickly assess the impact of any change.
- *
- * CATEGORIES
- * ──────────
- * sensitive_pii  – Government IDs, biometrics, date of birth, SSN
- * credential     – Passwords, PINs, security answers
- * financial      – Account / card / routing numbers
- * custom         – Application-specific exclusions
  */
 
 import type { TrackingSchema } from 'yourbank-design'
 
 const trackingSchema: TrackingSchema = {
-  version: '1.0.0',
+  version: '2.0.0',
   description:
-    'YourBank Adobe Web SDK field tracking exclusion schema. ' +
-    'Fields listed under blockedFields will have data-tracking-blocked="true" ' +
-    'set by the TrackingObserver, preventing Adobe Analytics from capturing ' +
-    'events on these elements.',
+    'YourBank analytics field tracking schema v2. ' +
+    'blockedFields prevent any events from sensitive fields. ' +
+    'fieldMap enriches tracked field events with business context metadata.',
 
-  /** Custom DOM event prefix. Adobe SDK rules should listen for:
+  /** Custom DOM event prefix. Any vendor should listen for:
    *  - yourbank:pageView
    *  - yourbank:fieldInteraction
    *  - yourbank:formSubmit
    */
   eventPrefix: 'yourbank:',
 
+  // ── Blocked fields ──────────────────────────────────────────────────────
+  // These fields NEVER generate events. Matching elements are stamped with
+  // data-tracking-blocked="true" so vendor rules can filter them natively too.
   blockedFields: [
     {
       selector: "[data-field-id='ssn']",
@@ -54,7 +55,7 @@ const trackingSchema: TrackingSchema = {
       category: 'sensitive_pii'
     },
     {
-      selector: "[data-field-id='password']",
+      selector: "[type='password']",
       reason: 'Password is a credential — capturing it would be a security violation',
       category: 'credential'
     },
@@ -68,21 +69,72 @@ const trackingSchema: TrackingSchema = {
       reason: 'Account number is sensitive financial data',
       category: 'financial'
     }
+  ],
+
+  // ── Field map ────────────────────────────────────────────────────────────
+  // Per-field enrichment: static metadata merged into event.detail.meta.
+  // Only tracked (non-blocked) fields should be listed here.
+  // The optional `events` array restricts which DOM events fire for that field.
+  fieldMap: [
+    {
+      selector: "[data-field-id='first-name']",
+      meta: { section: 'personal-info', label: 'First Name', required: true, step: 1 }
+    },
+    {
+      selector: "[data-field-id='last-name']",
+      meta: { section: 'personal-info', label: 'Last Name', required: true, step: 1 }
+    },
+    {
+      selector: "[data-field-id='email']",
+      meta: { section: 'personal-info', label: 'Email Address', required: true, step: 1 }
+    },
+    {
+      selector: "[data-field-id='phone']",
+      meta: { section: 'personal-info', label: 'Phone Number', required: false, step: 1 }
+    },
+    {
+      selector: "[data-field-id='loan-amount']",
+      meta: { section: 'loan-details', label: 'Requested Amount', required: true, step: 2 },
+      // Only fire on change/blur — avoid per-keystroke noise on numeric inputs
+      events: ['change', 'blur']
+    },
+    {
+      selector: "[data-field-id='loan-purpose']",
+      meta: { section: 'loan-details', label: 'Loan Purpose', required: true, step: 2 }
+    },
+    {
+      selector: "[data-field-id='monthly-income']",
+      meta: { section: 'loan-details', label: 'Monthly Gross Income', required: true, step: 2 },
+      events: ['change', 'blur']
+    },
+    {
+      selector: "button[type='submit']",
+      meta: { label: 'Submit Application', flow: 'loan-application' }
+    }
   ]
 }
 
 export default trackingSchema
 
 /**
- * BLOCKED FIELD QUICK-REFERENCE
- * ──────────────────────────────
+ * BLOCKED FIELDS QUICK-REFERENCE
+ * ────────────────────────────────
  * data-field-id        category        reason
  * ───────────────────  ──────────────  ────────────────────────────────────────
  * ssn                  sensitive_pii   Social Security Number
- * password             credential      Login / account password
+ * [type=password]      credential      Any password field
  * dob                  sensitive_pii   Date of birth
  * account-number       financial       Bank account number
  *
- * All other data-field-id values (first-name, last-name, email, phone,
- * loan-amount, loan-purpose, monthly-income) are TRACKED by default.
+ * TRACKED FIELDS (with enrichment)
+ * ─────────────────────────────────
+ * data-field-id        section          step  events
+ * ───────────────────  ───────────────  ────  ──────────────
+ * first-name           personal-info    1     focus,blur,change (default)
+ * last-name            personal-info    1     focus,blur,change (default)
+ * email                personal-info    1     focus,blur,change (default)
+ * phone                personal-info    1     focus,blur,change (default)
+ * loan-amount          loan-details     2     change,blur (override)
+ * loan-purpose         loan-details     2     change,focus,blur (default select)
+ * monthly-income       loan-details     2     change,blur (override)
  */

--- a/libs/yourbank-design/example/src/tracking-schema.ts
+++ b/libs/yourbank-design/example/src/tracking-schema.ts
@@ -1,0 +1,88 @@
+/**
+ * tracking-schema.ts
+ *
+ * This file is the canonical source of truth for which form fields are
+ * excluded from Adobe Web SDK event tracking in the YourBank example app.
+ *
+ * HOW TO IDENTIFY BLOCKED FIELDS
+ * ──────────────────────────────
+ * Each entry in `blockedFields` contains a CSS `selector`. The recommended
+ * convention for this codebase is the `data-field-id` attribute:
+ *
+ *   <input type="text" data-field-id="first-name" />   ← TRACKED
+ *   <input type="password" data-field-id="password" /> ← BLOCKED (see below)
+ *
+ * UI components do not need to import this schema or know about Adobe.
+ * The TrackingObserver reads the schema and stamps blocked elements with
+ * `data-tracking-blocked="true"` at runtime.
+ *
+ * GOVERNANCE
+ * ──────────
+ * Changes to this file should be reviewed by Privacy, Legal, and Analytics
+ * before merging. The `reason` and `category` fields document *why* a field
+ * is blocked so reviewers can quickly assess the impact of any change.
+ *
+ * CATEGORIES
+ * ──────────
+ * sensitive_pii  – Government IDs, biometrics, date of birth, SSN
+ * credential     – Passwords, PINs, security answers
+ * financial      – Account / card / routing numbers
+ * custom         – Application-specific exclusions
+ */
+
+import type { TrackingSchema } from 'yourbank-design'
+
+const trackingSchema: TrackingSchema = {
+  version: '1.0.0',
+  description:
+    'YourBank Adobe Web SDK field tracking exclusion schema. ' +
+    'Fields listed under blockedFields will have data-tracking-blocked="true" ' +
+    'set by the TrackingObserver, preventing Adobe Analytics from capturing ' +
+    'events on these elements.',
+
+  /** Custom DOM event prefix. Adobe SDK rules should listen for:
+   *  - yourbank:pageView
+   *  - yourbank:fieldInteraction
+   *  - yourbank:formSubmit
+   */
+  eventPrefix: 'yourbank:',
+
+  blockedFields: [
+    {
+      selector: "[data-field-id='ssn']",
+      reason: 'Social Security Number is sensitive PII — must never be tracked',
+      category: 'sensitive_pii'
+    },
+    {
+      selector: "[data-field-id='password']",
+      reason: 'Password is a credential — capturing it would be a security violation',
+      category: 'credential'
+    },
+    {
+      selector: "[data-field-id='dob']",
+      reason: 'Date of birth is sensitive PII under CCPA/GDPR',
+      category: 'sensitive_pii'
+    },
+    {
+      selector: "[data-field-id='account-number']",
+      reason: 'Account number is sensitive financial data',
+      category: 'financial'
+    }
+  ]
+}
+
+export default trackingSchema
+
+/**
+ * BLOCKED FIELD QUICK-REFERENCE
+ * ──────────────────────────────
+ * data-field-id        category        reason
+ * ───────────────────  ──────────────  ────────────────────────────────────────
+ * ssn                  sensitive_pii   Social Security Number
+ * password             credential      Login / account password
+ * dob                  sensitive_pii   Date of birth
+ * account-number       financial       Bank account number
+ *
+ * All other data-field-id values (first-name, last-name, email, phone,
+ * loan-amount, loan-purpose, monthly-income) are TRACKED by default.
+ */

--- a/libs/yourbank-design/src/index.tsx
+++ b/libs/yourbank-design/src/index.tsx
@@ -1,13 +1,26 @@
 import * as React from 'react'
 import styles from './styles.module.css'
 
-//header
+// Tracking
+export { TrackingObserver } from './tracking/TrackingObserver'
+export type {
+  TrackingSchema,
+  BlockedField,
+  BlockedFieldCategory,
+  TrackingEventDetail
+} from './tracking/types'
 
-const Header: React.FC = () => {
+// Header
+
+interface HeaderProps extends React.HTMLAttributes<HTMLElement> {
+  children?: React.ReactNode
+}
+
+const Header: React.FC<HeaderProps> = ({ children, ...props }) => {
   return (
-    <header className={styles.header}>
+    <header className={styles.header} {...props}>
       <h1 className={styles.logo}>YourBank</h1>
-      {/* Add navigation or other elements here */}
+      {children && <div className={styles.headerNav}>{children}</div>}
     </header>
   )
 }
@@ -187,3 +200,60 @@ export const LogoComponent: React.FC<LogoProps> = ({ className, style }) => {
     </svg>
   )
 }
+
+// ─── Form components ──────────────────────────────────────────────────────────
+// These components are thin, accessible wrappers around standard HTML elements.
+// They accept all native HTML attributes — including `data-field-id` — which
+// is the convention the TrackingObserver uses to identify fields in the schema.
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Identifies this field in the tracking schema. E.g. data-field-id="email" */
+  'data-field-id'?: string
+}
+
+export const Input: React.FC<InputProps> = (props) => (
+  <input className={styles.input} {...props} />
+)
+
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  'data-field-id'?: string
+  children: React.ReactNode
+}
+
+export const Select: React.FC<SelectProps> = ({ children, ...props }) => (
+  <select className={styles.input} {...props}>
+    {children}
+  </select>
+)
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  required?: boolean
+}
+
+export const Label: React.FC<LabelProps> = ({
+  required,
+  children,
+  ...props
+}) => (
+  <label className={styles.label} {...props}>
+    {children}
+    {required && (
+      <span className={styles.requiredMark} aria-hidden='true'>
+        {' '}
+        *
+      </span>
+    )}
+  </label>
+)
+
+interface FormGroupProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export const FormGroup: React.FC<FormGroupProps> = ({ children, className }) => (
+  <div className={`${styles.formGroup} ${className || ''}`}>{children}</div>
+)

--- a/libs/yourbank-design/src/index.tsx
+++ b/libs/yourbank-design/src/index.tsx
@@ -7,6 +7,7 @@ export type {
   TrackingSchema,
   BlockedField,
   BlockedFieldCategory,
+  FieldDefinition,
   TrackingEventDetail
 } from './tracking/types'
 

--- a/libs/yourbank-design/src/styles.module.css
+++ b/libs/yourbank-design/src/styles.module.css
@@ -250,3 +250,133 @@ em {
 .icon-white {
   color: #ffffff; /* White color */
 }
+
+/* ─── Header nav ──────────────────────────────────────────────────────────── */
+
+.headerNav {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.headerNav button,
+.headerNav a {
+  background: transparent;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  color: #fff;
+  padding: 6px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  text-decoration: none;
+}
+
+.headerNav button:hover,
+.headerNav a:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: #fff;
+}
+
+.headerNav button.active,
+.headerNav a.active {
+  background: rgba(255, 255, 255, 0.25);
+  border-color: #fff;
+}
+
+/* ─── Form components ─────────────────────────────────────────────────────── */
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #444;
+  letter-spacing: 0.3px;
+}
+
+.requiredMark {
+  color: #c0392b;
+  font-weight: bold;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 15px;
+  color: #333;
+  background: #fff;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  appearance: none;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #c0392b;
+  box-shadow: 0 0 0 3px rgba(192, 57, 43, 0.15);
+}
+
+.input:disabled {
+  background: #f5f5f5;
+  color: #999;
+  cursor: not-allowed;
+}
+
+/* Blocked fields get a subtle lock indicator applied automatically by
+   the TrackingObserver via data-tracking-blocked="true".
+   No component code change is required — the CSS selector does the work. */
+.input[data-tracking-blocked='true'] {
+  border-color: #888;
+  background: #fafafa;
+}
+
+/* ─── Form layout helpers ─────────────────────────────────────────────────── */
+
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 24px;
+}
+
+@media (max-width: 600px) {
+  .formRow {
+    grid-template-columns: 1fr;
+  }
+}
+
+.formSection {
+  margin-bottom: 32px;
+}
+
+.formSectionTitle {
+  font-size: 16px;
+  font-weight: 700;
+  color: #c0392b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e8e8e8;
+  margin-bottom: 20px;
+}
+
+/* secondary button variant */
+.secondary {
+  background-color: transparent;
+  color: #c0392b;
+  border: 2px solid #c0392b;
+}
+
+.secondary:hover {
+  background-color: #fdf0ef;
+}

--- a/libs/yourbank-design/src/tracking/TrackingObserver.ts
+++ b/libs/yourbank-design/src/tracking/TrackingObserver.ts
@@ -1,0 +1,215 @@
+import { TrackingSchema, TrackingEventDetail } from './types'
+
+/**
+ * TrackingObserver
+ *
+ * A framework-agnostic DOM observer that enables Adobe Web SDK event
+ * collection across a React application without requiring any changes to
+ * individual UI components.
+ *
+ * HOW IT WORKS
+ * ------------
+ * 1. **Schema-driven blocking** – On startup (and whenever new nodes are
+ *    added to the DOM) the observer walks matching elements and stamps them
+ *    with `data-tracking-blocked="true"`. Adobe SDK rules can use this
+ *    attribute as a condition to skip those elements natively.
+ *
+ * 2. **Event delegation** – A single capture-phase listener on `document`
+ *    intercepts input, change, focus, blur, click, and submit events. Events
+ *    from blocked elements (or their descendants) are silently dropped.
+ *
+ * 3. **Custom events** – For every allowed interaction a `CustomEvent` is
+ *    dispatched on `document` with the prefix defined in the schema
+ *    (e.g. `yourbank:fieldInteraction`). Adobe SDK Data Collection rules
+ *    can listen to these events and forward them to Adobe Analytics /
+ *    Adobe Experience Platform.
+ *
+ * USAGE
+ * -----
+ * ```ts
+ * import { TrackingObserver } from 'yourbank-design'
+ * import schema from './tracking-schema'
+ *
+ * const observer = new TrackingObserver(schema)
+ * observer.start()
+ * observer.setPage('loan-application')
+ *
+ * // On unmount / SPA navigation:
+ * observer.stop()
+ * ```
+ *
+ * ADOBE SDK INTEGRATION
+ * ---------------------
+ * In Adobe Experience Platform Data Collection (Launch/Tags), create rules
+ * that listen for these custom events:
+ *
+ *   - `yourbank:pageView`         – fired when setPage() is called
+ *   - `yourbank:fieldInteraction` – fired on input / change / focus / blur
+ *   - `yourbank:formSubmit`       – fired on form submit
+ *
+ * Add a condition on each rule: Element Attribute `data-tracking-blocked`
+ * Does Not Equal `true` (belt-and-suspenders guard in addition to the
+ * observer's own filtering).
+ */
+export class TrackingObserver {
+  private schema: TrackingSchema
+  private mutationObserver: MutationObserver | null = null
+  private currentPage: string = ''
+  private listening = false
+
+  // Bound reference kept so we can cleanly removeEventListener later
+  private readonly handleEvent: (event: Event) => void
+
+  constructor(schema: TrackingSchema) {
+    this.schema = schema
+    this.handleEvent = this._handleEvent.bind(this)
+  }
+
+  // ─── Public API ───────────────────────────────────────────────────────────
+
+  /**
+   * Announce a page/view transition.
+   * Call this whenever the visible page changes (SPA route change, wizard step, etc.)
+   */
+  setPage(pageName: string): void {
+    this.currentPage = pageName
+    this._dispatch('pageView', {
+      eventType: 'pageView',
+      pageName,
+      timestamp: new Date().toISOString()
+    })
+  }
+
+  /** Begin observing DOM events and mutations. Safe to call multiple times. */
+  start(): void {
+    if (this.listening) return
+    this.listening = true
+
+    const events = ['input', 'change', 'focus', 'blur', 'click', 'submit']
+    events.forEach(type => document.addEventListener(type, this.handleEvent, true))
+
+    // Watch for newly-mounted nodes and stamp them immediately
+    this.mutationObserver = new MutationObserver(mutations => {
+      mutations.forEach(({ addedNodes }) => {
+        addedNodes.forEach(node => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            this._stampBlocked(node as Element)
+          }
+        })
+      })
+    })
+
+    this.mutationObserver.observe(document.body, { childList: true, subtree: true })
+
+    // Stamp any elements already present
+    this._stampBlocked(document.body)
+  }
+
+  /** Stop observing and clean up all listeners. */
+  stop(): void {
+    if (!this.listening) return
+    this.listening = false
+
+    const events = ['input', 'change', 'focus', 'blur', 'click', 'submit']
+    events.forEach(type => document.removeEventListener(type, this.handleEvent, true))
+
+    this.mutationObserver?.disconnect()
+    this.mutationObserver = null
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  /**
+   * Walk `root` and apply `data-tracking-blocked` attributes to every element
+   * that matches a blocked-field selector from the schema. Adobe SDK and CSS
+   * can use this attribute without any further JavaScript.
+   */
+  private _stampBlocked(root: Element): void {
+    for (const rule of this.schema.blockedFields) {
+      try {
+        root.querySelectorAll(rule.selector).forEach(el => {
+          el.setAttribute('data-tracking-blocked', 'true')
+          el.setAttribute('data-tracking-block-reason', rule.reason)
+          el.setAttribute('data-tracking-block-category', rule.category)
+        })
+        // Also check the root node itself
+        if (root.matches?.(rule.selector)) {
+          root.setAttribute('data-tracking-blocked', 'true')
+          root.setAttribute('data-tracking-block-reason', rule.reason)
+          root.setAttribute('data-tracking-block-category', rule.category)
+        }
+      } catch {
+        // Tolerate invalid selectors so a bad schema entry doesn't break the page
+      }
+    }
+  }
+
+  /**
+   * Returns true when `element` or any of its ancestors is blocked — either
+   * via the stamped attribute (fast path) or by direct selector match (covers
+   * the case where the element was in the DOM before start() was called).
+   */
+  private _isBlocked(element: Element): boolean {
+    let node: Element | null = element
+    while (node) {
+      if (node.getAttribute('data-tracking-blocked') === 'true') return true
+      for (const rule of this.schema.blockedFields) {
+        try {
+          if (node.matches(rule.selector)) return true
+        } catch {
+          // ignore
+        }
+      }
+      node = node.parentElement
+    }
+    return false
+  }
+
+  private _handleEvent(event: Event): void {
+    const target = event.target as HTMLElement
+    if (!target?.tagName) return
+
+    const tag = target.tagName.toUpperCase()
+    const isField = ['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)
+    const isButton = tag === 'BUTTON'
+    const isAnchor = tag === 'A'
+    const isForm = tag === 'FORM'
+
+    // Only handle relevant element/event pairings
+    if (['input', 'change', 'focus', 'blur'].includes(event.type) && !isField) return
+    if (event.type === 'submit' && !isForm) return
+    if (event.type === 'click' && !isButton && !isAnchor && !target.dataset.trackClick) return
+
+    // Drop events from blocked elements
+    if (this._isBlocked(target)) return
+
+    const detail: TrackingEventDetail = {
+      eventType: event.type,
+      timestamp: new Date().toISOString(),
+      pageName: this.currentPage,
+      fieldId: target.dataset.fieldId,
+      fieldType: isField ? (target as HTMLInputElement).type : undefined,
+      elementTag: tag.toLowerCase()
+    }
+
+    // Capture visible label text for buttons/links — never capture input values
+    if (isButton || isAnchor) {
+      detail.elementText = target.textContent?.trim()
+    }
+
+    if (isForm) {
+      detail.fieldId = target.id || target.dataset.formId
+      this._dispatch('formSubmit', detail)
+    } else {
+      this._dispatch('fieldInteraction', detail)
+    }
+  }
+
+  private _dispatch(
+    name: string,
+    detail: TrackingEventDetail | Record<string, unknown>
+  ): void {
+    const type = `${this.schema.eventPrefix}${name}`
+    document.dispatchEvent(new CustomEvent(type, { bubbles: true, detail }))
+  }
+}

--- a/libs/yourbank-design/src/tracking/TrackingObserver.ts
+++ b/libs/yourbank-design/src/tracking/TrackingObserver.ts
@@ -1,11 +1,11 @@
 import { TrackingSchema, TrackingEventDetail } from './types'
 
 /**
- * TrackingObserver
+ * TrackingObserver v2
  *
- * A framework-agnostic DOM observer that enables Adobe Web SDK event
- * collection across a React application without requiring any changes to
- * individual UI components.
+ * A framework-agnostic DOM observer that enables analytics event collection
+ * across a React application without requiring any changes to individual UI
+ * components.
  *
  * HOW IT WORKS
  * ------------
@@ -18,11 +18,21 @@ import { TrackingSchema, TrackingEventDetail } from './types'
  *    intercepts input, change, focus, blur, click, and submit events. Events
  *    from blocked elements (or their descendants) are silently dropped.
  *
- * 3. **Custom events** – For every allowed interaction a `CustomEvent` is
+ * 3. **Component type resolution** – Every event payload includes a
+ *    `componentType` string (e.g. "input:text", "button:submit") derived
+ *    from the element's tag and type attribute. Overridable via data-component.
+ *
+ * 4. **Field enrichment** – If the schema defines a `fieldMap`, the observer
+ *    looks up the interacted element and merges static `meta` key/values into
+ *    the event payload. No component code changes required.
+ *
+ * 5. **Default event filtering** – Each component type fires only meaningful
+ *    events by default (e.g. text inputs fire blur/change, not per-keystroke
+ *    input). Teams can override per field via fieldMap[].events.
+ *
+ * 6. **Custom events** – For every allowed interaction a `CustomEvent` is
  *    dispatched on `document` with the prefix defined in the schema
- *    (e.g. `yourbank:fieldInteraction`). Adobe SDK Data Collection rules
- *    can listen to these events and forward them to Adobe Analytics /
- *    Adobe Experience Platform.
+ *    (e.g. `yourbank:fieldInteraction`). Any analytics vendor can listen.
  *
  * USAGE
  * -----
@@ -38,18 +48,21 @@ import { TrackingSchema, TrackingEventDetail } from './types'
  * observer.stop()
  * ```
  *
- * ADOBE SDK INTEGRATION
- * ---------------------
- * In Adobe Experience Platform Data Collection (Launch/Tags), create rules
- * that listen for these custom events:
+ * VENDOR INTEGRATION
+ * ------------------
+ * Any vendor can subscribe to custom events on document:
  *
- *   - `yourbank:pageView`         – fired when setPage() is called
- *   - `yourbank:fieldInteraction` – fired on input / change / focus / blur
- *   - `yourbank:formSubmit`       – fired on form submit
+ *   document.addEventListener('yourbank:fieldInteraction', e => {
+ *     // e.detail.componentType — "input:text", "button:submit", etc.
+ *     // e.detail.meta         — business context from schema fieldMap
+ *     // e.detail.fieldId      — data-field-id value
+ *     // e.detail.pageName     — from observer.setPage()
+ *   })
  *
- * Add a condition on each rule: Element Attribute `data-tracking-blocked`
- * Does Not Equal `true` (belt-and-suspenders guard in addition to the
- * observer's own filtering).
+ * BACKWARD COMPATIBILITY
+ * ----------------------
+ * V1 schemas (no fieldMap) continue to work. meta and componentType will
+ * simply be undefined in event payloads.
  */
 export class TrackingObserver {
   private schema: TrackingSchema
@@ -121,8 +134,7 @@ export class TrackingObserver {
 
   /**
    * Walk `root` and apply `data-tracking-blocked` attributes to every element
-   * that matches a blocked-field selector from the schema. Adobe SDK and CSS
-   * can use this attribute without any further JavaScript.
+   * that matches a blocked-field selector from the schema.
    */
   private _stampBlocked(root: Element): void {
     for (const rule of this.schema.blockedFields) {
@@ -132,7 +144,6 @@ export class TrackingObserver {
           el.setAttribute('data-tracking-block-reason', rule.reason)
           el.setAttribute('data-tracking-block-category', rule.category)
         })
-        // Also check the root node itself
         if (root.matches?.(rule.selector)) {
           root.setAttribute('data-tracking-blocked', 'true')
           root.setAttribute('data-tracking-block-reason', rule.reason)
@@ -145,9 +156,7 @@ export class TrackingObserver {
   }
 
   /**
-   * Returns true when `element` or any of its ancestors is blocked — either
-   * via the stamped attribute (fast path) or by direct selector match (covers
-   * the case where the element was in the DOM before start() was called).
+   * Returns true when `element` or any of its ancestors is blocked.
    */
   private _isBlocked(element: Element): boolean {
     let node: Element | null = element
@@ -165,6 +174,77 @@ export class TrackingObserver {
     return false
   }
 
+  /**
+   * Resolve the design system component type for an element.
+   *
+   * Resolution order:
+   * 1. data-component attribute (explicit override)
+   * 2. Derived from tagName + type attribute
+   */
+  private _resolveComponentType(el: Element): string {
+    const override = el.getAttribute('data-component')
+    if (override) return override
+
+    const tag = el.tagName.toUpperCase()
+    const type = (el as HTMLInputElement).type?.toLowerCase() ?? ''
+
+    if (tag === 'INPUT') {
+      if (['text', 'email', 'tel', 'search', 'url'].includes(type)) return 'input:text'
+      if (type === 'password') return 'input:password'
+      if (type === 'checkbox') return 'input:checkbox'
+      if (type === 'radio') return 'input:radio'
+      if (type === 'number') return 'input:number'
+      if (type === 'hidden') return 'input:hidden'
+      if (['date', 'datetime-local', 'month', 'week', 'time'].includes(type)) return 'input:date'
+      return `input:${type || 'text'}`
+    }
+    if (tag === 'BUTTON') {
+      if (type === 'submit') return 'button:submit'
+      if (type === 'reset') return 'button:reset'
+      return 'button:button'
+    }
+    if (tag === 'SELECT') return 'select'
+    if (tag === 'TEXTAREA') return 'textarea'
+    if (tag === 'A') return 'link'
+    if (tag === 'FORM') return 'form'
+    return tag.toLowerCase()
+  }
+
+  /**
+   * Return the default set of event types that should fire for a given
+   * component type. Avoids per-keystroke noise on text inputs by default.
+   */
+  private _getDefaultEvents(componentType: string): string[] {
+    if (componentType === 'input:hidden') return []
+    if (componentType === 'input:checkbox' || componentType === 'input:radio') return ['change']
+    if (componentType === 'input:date') return ['change', 'blur']
+    if (componentType.startsWith('input:') || componentType === 'textarea') return ['focus', 'blur', 'change']
+    if (componentType.startsWith('button:') || componentType === 'link') return ['click']
+    if (componentType === 'select') return ['change', 'focus', 'blur']
+    if (componentType === 'form') return ['submit']
+    return ['click', 'change', 'blur']
+  }
+
+  /**
+   * Look up the first matching FieldDefinition in schema.fieldMap for el.
+   * Returns the meta object, or undefined if no match / no fieldMap.
+   */
+  private _findFieldMeta(
+    el: Element
+  ): { meta: Record<string, string | number | boolean>; events?: string[] } | undefined {
+    if (!this.schema.fieldMap) return undefined
+    for (const def of this.schema.fieldMap) {
+      try {
+        if (el.matches(def.selector)) {
+          return { meta: def.meta, events: def.events }
+        }
+      } catch {
+        // ignore invalid selectors
+      }
+    }
+    return undefined
+  }
+
   private _handleEvent(event: Event): void {
     const target = event.target as HTMLElement
     if (!target?.tagName) return
@@ -175,7 +255,7 @@ export class TrackingObserver {
     const isAnchor = tag === 'A'
     const isForm = tag === 'FORM'
 
-    // Only handle relevant element/event pairings
+    // Only handle relevant element/event pairings (coarse pre-filter)
     if (['input', 'change', 'focus', 'blur'].includes(event.type) && !isField) return
     if (event.type === 'submit' && !isForm) return
     if (event.type === 'click' && !isButton && !isAnchor && !target.dataset.trackClick) return
@@ -183,13 +263,28 @@ export class TrackingObserver {
     // Drop events from blocked elements
     if (this._isBlocked(target)) return
 
+    // Resolve component type — hidden inputs never fire
+    const componentType = this._resolveComponentType(target)
+    if (componentType === 'input:hidden') return
+
+    // Determine allowed events: fieldMap override → default for componentType
+    const fieldDef = this._findFieldMeta(target)
+    const allowedEvents = fieldDef?.events ?? this._getDefaultEvents(componentType)
+    if (!allowedEvents.includes(event.type)) return
+
     const detail: TrackingEventDetail = {
       eventType: event.type,
       timestamp: new Date().toISOString(),
       pageName: this.currentPage,
       fieldId: target.dataset.fieldId,
       fieldType: isField ? (target as HTMLInputElement).type : undefined,
-      elementTag: tag.toLowerCase()
+      elementTag: tag.toLowerCase(),
+      componentType
+    }
+
+    // Merge field enrichment metadata
+    if (fieldDef?.meta) {
+      detail.meta = fieldDef.meta
     }
 
     // Capture visible label text for buttons/links — never capture input values

--- a/libs/yourbank-design/src/tracking/types.ts
+++ b/libs/yourbank-design/src/tracking/types.ts
@@ -1,0 +1,98 @@
+/**
+ * YourBank Tracking Schema Types
+ *
+ * This schema defines which form fields are excluded from Adobe Web SDK event
+ * tracking. The TrackingObserver reads this schema at runtime and:
+ *   1. Sets `data-tracking-blocked="true"` on matching DOM elements so Adobe
+ *      SDK rules can natively filter them out.
+ *   2. Suppresses custom `yourbank:*` events for those elements.
+ *
+ * FIELD IDENTIFICATION
+ * --------------------
+ * Fields are identified by a CSS `selector`. The recommended convention is to
+ * use a `data-field-id` attribute:
+ *
+ *   <input type="text" data-field-id="first-name" />  ← tracked
+ *   <input type="text" data-field-id="ssn" />          ← blocked (see schema)
+ *
+ * UI components do NOT need to import or reference this schema. The
+ * TrackingObserver applies blocking transparently via DOM observation.
+ */
+
+/** Categories of sensitive data that should be excluded from tracking */
+export type BlockedFieldCategory =
+  | 'sensitive_pii'  // Social Security Number, date of birth, government IDs
+  | 'credential'     // Passwords, PINs, security questions
+  | 'financial'      // Account numbers, card numbers, routing numbers
+  | 'custom'         // Application-specific exclusions
+
+/** A single field exclusion rule */
+export interface BlockedField {
+  /**
+   * CSS selector used to identify the element in the DOM.
+   * Recommended pattern: `[data-field-id='<id>']`
+   * Any valid CSS selector is supported.
+   */
+  selector: string
+
+  /** Human-readable explanation of why this field is excluded */
+  reason: string
+
+  /** Data sensitivity category */
+  category: BlockedFieldCategory
+}
+
+/**
+ * Top-level schema consumed by TrackingObserver.
+ * Typically stored in a versioned JSON file (e.g. tracking-schema.json)
+ * alongside your application and committed to source control so that
+ * product, legal, and privacy teams can review which fields are excluded.
+ */
+export interface TrackingSchema {
+  /** Semantic version of this schema document */
+  version: string
+
+  /** Optional human-readable description */
+  description?: string
+
+  /**
+   * Fields that must NOT generate Adobe Web SDK tracking events.
+   * Any element matching one of these selectors — or any ancestor — is skipped.
+   */
+  blockedFields: BlockedField[]
+
+  /**
+   * Prefix applied to all custom DOM events dispatched by the observer.
+   * Adobe SDK rules should listen for `${eventPrefix}fieldInteraction`,
+   * `${eventPrefix}formSubmit`, and `${eventPrefix}pageView`.
+   * Example: "yourbank:"
+   */
+  eventPrefix: string
+}
+
+/** Payload attached to every custom tracking event's `detail` property */
+export interface TrackingEventDetail {
+  /** The native DOM event type that triggered this (input, change, click, …) */
+  eventType: string
+
+  /** Value of the `data-field-id` attribute on the interacted element */
+  fieldId?: string
+
+  /** `type` attribute of <input> elements (text, email, tel, …) */
+  fieldType?: string
+
+  /** Page/view name set via `TrackingObserver.setPage()` */
+  pageName?: string
+
+  /** ISO-8601 timestamp */
+  timestamp: string
+
+  /** Lower-cased tag name of the target element */
+  elementTag?: string
+
+  /**
+   * Visible text of the element — only populated for buttons and links.
+   * Input field *values* are never captured.
+   */
+  elementText?: string
+}

--- a/libs/yourbank-design/src/tracking/types.ts
+++ b/libs/yourbank-design/src/tracking/types.ts
@@ -19,6 +19,32 @@
  * TrackingObserver applies blocking transparently via DOM observation.
  */
 
+/**
+ * A single field enrichment rule.
+ * Maps a CSS selector to static metadata merged into every event for that field.
+ */
+export interface FieldDefinition {
+  /**
+   * CSS selector identifying the field.
+   * Same convention as blockedFields — data-field-id recommended.
+   */
+  selector: string
+
+  /**
+   * Arbitrary key/value pairs merged into event.detail.meta for this field.
+   * Use for business context: section, label, step, required, flow, etc.
+   * Values must be JSON-serializable primitives.
+   */
+  meta: Record<string, string | number | boolean>
+
+  /**
+   * Restrict which DOM event types generate tracking events for this field.
+   * Omit to use the observer's default event set for the component type.
+   * Example: ['change', 'blur'] — avoid per-keystroke noise on text fields.
+   */
+  events?: Array<'input' | 'change' | 'focus' | 'blur' | 'click' | 'submit'>
+}
+
 /** Categories of sensitive data that should be excluded from tracking */
 export type BlockedFieldCategory =
   | 'sensitive_pii'  // Social Security Number, date of birth, government IDs
@@ -68,6 +94,14 @@ export interface TrackingSchema {
    * Example: "yourbank:"
    */
   eventPrefix: string
+
+  /**
+   * Optional per-field enrichment rules.
+   * Each entry maps a CSS selector to static metadata merged into event payloads.
+   * Also supports per-field event filtering via the `events` property.
+   * V1 schemas without fieldMap continue to work — meta and componentType will be undefined.
+   */
+  fieldMap?: FieldDefinition[]
 }
 
 /** Payload attached to every custom tracking event's `detail` property */
@@ -95,4 +129,18 @@ export interface TrackingEventDetail {
    * Input field *values* are never captured.
    */
   elementText?: string
+
+  /**
+   * Design system component type resolved from the element.
+   * Format: "tag:subtype" e.g. "input:text", "button:submit", "select".
+   * Derived from tagName + type attribute, overridable via data-component attribute.
+   */
+  componentType?: string
+
+  /**
+   * Static metadata from the schema's fieldMap for this field.
+   * Contains business context: section, label, step, required, flow, etc.
+   * Only present when the field has a matching FieldDefinition in the schema.
+   */
+  meta?: Record<string, string | number | boolean>
 }


### PR DESCRIPTION
Demonstrates:
- Multi-page navigation (Landing → Loan Application Form → Confirmation)
- Form with editable fields and submit button using new Input/Label/FormGroup/Select components
- TrackingObserver: a DOM observer that dispatches custom yourbank:* events the
  Adobe Web SDK can listen to via Data Collection rules, without any changes to
  UI component code
- Schema-driven field blocking: tracking-schema.ts declares which fields are
  sensitive (SSN, DOB, account number, password) using CSS selectors keyed on
  data-field-id attributes; the observer stamps blocked elements with
  data-tracking-blocked="true" at runtime
- Live Adobe SDK Event Console in the example app shows which events are
  dispatched (blocked fields are transparently suppressed)
- TRACKING.md spec documents the schema format, governance process, field
  conventions, and Adobe Launch/Tags integration pattern

https://claude.ai/code/session_01Gh9AKQFN1qzRezxoMT4Px5