### PR TITLE
fix: build example app via working-directory instead of missing works…

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,8 @@ jobs:
         run: yarn workspace yourbank-design build
 
       - name: Build example app
-        run: yarn workspace yourbank-design-example build
+        working-directory: libs/yourbank-design/example
+        run: yarn build
         env:
           # Required for CRA to produce correct relative asset paths on GitHub Pages
           PUBLIC_URL: /YourBank


### PR DESCRIPTION
…pace

The example app is not registered as a yarn workspace (it lives two levels under libs/), so 'yarn workspace yourbank-design-example build' fails with Unknown workspace. Use 'working-directory' + 'yarn build' instead.

https://claude.ai/code/session_01Gh9AKQFN1qzRezxoMT4Px5