### PR TITLE
fix: add SKIP_PREFLIGHT_CHECK=true to suppress monorepo babel-loader …

### DIFF
--- a/libs/yourbank-design/example/.env
+++ b/libs/yourbank-design/example/.env
@@ -1,0 +1,4 @@
+# CRA preflight check flags a babel-loader version mismatch caused by the
+# monorepo's hoisted node_modules. This is a known false positive in monorepos
+# and does not affect the build output.
+SKIP_PREFLIGHT_CHECK=true


### PR DESCRIPTION
…false positive

CRA preflight check fails in the monorepo because babel-loader 8.3.0 is hoisted to the root node_modules while react-scripts expects 8.1.0. This is a known monorepo false positive and does not affect build output.

https://claude.ai/code/session_01Gh9AKQFN1qzRezxoMT4Px5