### PR TITLE
fix: set NODE_OPTIONS=--openssl-legacy-provider for Node 18 + CRA 3 c…

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -43,6 +43,9 @@ jobs:
         env:
           # Required for CRA to produce correct relative asset paths on GitHub Pages
           PUBLIC_URL: /YourBank
+          # CRA 3.x uses webpack 4 which uses a legacy OpenSSL hash that Node 17+
+          # disabled by default. This flag re-enables it without downgrading Node.
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
…ompat

CRA 3.x uses webpack 4 which calls createHash('md4') — an algorithm disabled in OpenSSL 3 (Node 17+). The legacy provider flag re-enables it without downgrading Node or upgrading CRA.

https://claude.ai/code/session_01Gh9AKQFN1qzRezxoMT4Px5