### PR TITLE
fix: wrap lock emoji in accessible span in ConfirmationPage

### DIFF
--- a/libs/yourbank-design/example/src/pages/ConfirmationPage.tsx
+++ b/libs/yourbank-design/example/src/pages/ConfirmationPage.tsx
@@ -125,7 +125,7 @@ const ConfirmationPage: React.FC<ConfirmationPageProps> = ({ formData, onBack })
               marginBottom: 0
             }}
           >
-            🔒 Protected fields (SSN, Date of Birth, Account Number) are not
+            <span role="img" aria-label="lock">🔒</span> Protected fields (SSN, Date of Birth, Account Number) are not
             displayed for security.
           </p>
         </div>


### PR DESCRIPTION
CRA CI treats a11y warnings as errors. Wraps the bare lock emoji with <span role="img" aria-label="lock"> to satisfy jsx-a11y/accessible-emoji.

https://claude.ai/code/session_01Gh9AKQFN1qzRezxoMT4Px5