### PR TITLE
fix: add NODE_OPTIONS to library build step — microbundle-crl uses we…

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Build design system library
         run: yarn workspace yourbank-design build
+        env:
+          # microbundle-crl uses webpack internally — same Node 18 OpenSSL fix needed
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Build example app
         working-directory: libs/yourbank-design/example


### PR DESCRIPTION
…bpack

microbundle-crl (used to build yourbank-design) bundles with webpack 4, which has the same Node 18 OpenSSL incompatibility as CRA. Without this flag the library build silently fails, leaving a stale dist/ that is missing TrackingObserver, Input, Select etc., causing the deployed example app to crash immediately with a blank page.

https://claude.ai/code/session_01Gh9AKQFN1qzRezxoMT4Px5